### PR TITLE
contract: change wallet code

### DIFF
--- a/contracts/exchange/api/BaseContract.sol
+++ b/contracts/exchange/api/BaseContract.sol
@@ -34,6 +34,25 @@ contract BaseContract is ReentrancyGuardUpgradeable {
     return sub;
   }
 
+  /// @notice Checks if a signer has a permissions in an account or associated subaccounts
+  /// @param acc The account
+  /// @param signer The signer's address
+  function _requireSignerInAccount(Account storage acc, address signer) internal {
+    if (acc.signers[signer] != 0) {
+      return;
+    }
+    bool isSubAccSigner = false;
+    uint256 numSubAccs = acc.subAccounts.length;
+    for (uint256 i; i < numSubAccs; ++i) {
+      SubAccount storage subAcc = _requireSubAccount(acc.subAccounts[i]);
+      if (subAcc.signers[signer] != 0) {
+        isSubAccSigner = true;
+        break;
+      }
+    }
+    require(isSubAccSigner, "signer not tagged to account");
+  }
+
   // Verify that the signatures are from the list of eligible signers, signer of each signature has admin permissions and those signatures form a simple majority
   function _requireSignatureQuorum(
     mapping(address => uint64) storage eligibleSigners,

--- a/contracts/exchange/api/WalletRecoveryContract.sol
+++ b/contracts/exchange/api/WalletRecoveryContract.sol
@@ -26,6 +26,7 @@ contract WalletRecoveryContract is BaseContract {
     Account storage acc = _requireAccount(accID);
 
     // ---------- Signature Verification -----------
+    _requireSignerInAccount(acc, sig.signer);
     _preventReplay(hashAddRecoveryAddress(accID, sig.signer, recoveryAddress, sig.nonce), sig);
     // ------- End of Signature Verification -------
 
@@ -50,6 +51,7 @@ contract WalletRecoveryContract is BaseContract {
     Account storage acc = _requireAccount(accID);
 
     // ---------- Signature Verification -----------
+    _requireSignerInAccount(acc, sig.signer);
     _preventReplay(hashRemoveRecoveryAddress(accID, sig.signer, recoveryAddress, sig.nonce), sig);
     // ------- End of Signature Verification -------
 

--- a/test/foundry/api/WalletRecoveryContract.t.sol
+++ b/test/foundry/api/WalletRecoveryContract.t.sol
@@ -116,7 +116,7 @@ contract WalletRecoveryContractTest is APIBase {
     vm.expectRevert("invalid signature");
     removeRecoveryAddressHelper(
       subAccSigner,
-      users.walletFourPrivateKey,
+      subAccSignerPrivateKey,
       accountID,
       accSigner,
       accSignerRecoveryAddressOne
@@ -125,7 +125,7 @@ contract WalletRecoveryContractTest is APIBase {
   }
 
   function testRecoverAddress() public {
-    addRecoveryAddressHelper(accSigner, users.walletOnePrivateKey, accountID, accSigner, accSignerRecoveryAddressOne);
+    addRecoveryAddressHelper(accSigner, accSignerPrivateKey, accountID, accSigner, accSignerRecoveryAddressOne);
     progressToNextTxn();
     recoverAddressHelper(
       accSignerRecoveryAddressOne,
@@ -201,6 +201,17 @@ contract WalletRecoveryContractTest is APIBase {
       accSigner,
       accSignerRecoveryAddressOne,
       newAddressOne
+    );
+  }
+
+  function testSignerNotTaggedToAccount() public {
+    vm.expectRevert("signer not tagged to account");
+    addRecoveryAddressHelper(
+      users.walletSeven,
+      users.walletSevenPrivateKey,
+      accountID,
+      subAccSigner,
+      accSignerRecoveryAddressOne
     );
   }
 }


### PR DESCRIPTION
The recoverySigner must be a signer of the account or a recovery signer for the oldSigner. We add for the ability of the recoverySigner to do this.