### PR TITLE
implement Config apis

### DIFF
--- a/contracts/exchange/GRVTExchange.sol
+++ b/contracts/exchange/GRVTExchange.sol
@@ -11,24 +11,17 @@ import "./api/TransferContract.sol";
 import "./api/WalletRecoveryContract.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-// import "hardhat/console.sol";
-
-// import {BlackScholes as BS} from "./blackscholes/BlackScholes.sol";
-
 contract GRVTExchange is
   Initializable,
   AccountContract,
+  ConfigContract,
   OracleContract,
   SubAccountContract,
   TradeContract,
   TransferContract,
   WalletRecoveryContract
 {
-  function initialize(bytes32[] memory _initialConfig) public initializer {
+  function initialize() public initializer {
     __ReentrancyGuard_init();
-    mapping(ConfigID => bytes32) storage configs = state.configs;
-    for (uint i; i < _initialConfig.length; ++i) {
-      configs[ConfigID(i)] = _initialConfig[i];
-    }
   }
 }

--- a/contracts/exchange/api/ConfigContract.sol
+++ b/contracts/exchange/api/ConfigContract.sol
@@ -4,115 +4,139 @@ pragma solidity ^0.8.20;
 import "./BaseContract.sol";
 import "../types/DataStructure.sol";
 import "./signature/generated/ConfigSig.sol";
-import {ConfigID as CfgID, ConfigTimelockRule as Rule} from "../types/DataStructure.sol";
+import {ConfigID, ConfigTimelockRule as Rule} from "../types/DataStructure.sol";
 import "../util/Address.sol";
 
+///////////////////////////////////////////////////////////////////
+/// Config Contract supports
+///  - (1) retrieving the current value for a config type
+///  - (2) changing the value of a config type
+///
+/// Terms
+///   - 1-dimensional Config
+///       Store the current value of all 1 dimensional config. 1D config is a simple key -> value mapping
+///       Eg: (AdminFeeSubAccountID) = 1357902468
+///           (AdminRecoveryAddress) = 0xc0ffee254729296a45a3885639AC7E10F9d54979
+///
+///   - 2-dimensional Config
+///      Store the current value of all 2 dimensional config.
+///      A 2D config needs to be referred by both (key, subKey)
+///      This is mainly to support risk configs for different underlying currency
+///      Eg: (PortfolioInitialMarginFactor, BTC) = 1.2
+///          (PortfolioInitialMarginFactor, DOGE) = 1.5
+///
+/// Reading a config value
+///  - Every config value is encoded as a byte32. Storing uint, int, address,
+///    hash will convert the value to a bytes32 representation internally
+///  - The value of 1D config is stored in `config1DValues` mapping
+///    To read this we need only the (key) of the config
+///  - The value of 2D config is stored in `config2DValues` mapping.
+///    To read this we need both the (key, subKey) of the config
+///
+/// Changing config
+///  - Every config change is timelocked. The timelock duration is determined
+///    by the magnitude of change in value (for numerical config) and the config type
+///  - The hardcoded timelock rules for each ConfigID determine the timelock duration
+///  - In order to make changes to a config value, the operator needs to first
+///    schedule the change by calling `scheduleConfig. The contract will `lock`
+///    the config for the duration of the timelock
+///  - After the timelock duration has passed, the operator can then change to
+///    the new value by calling `setConfig`
+///
+///////////////////////////////////////////////////////////////////
 contract ConfigContract is BaseContract {
   // --------------- Constants ---------------
   uint private constant CENTIBEEP = 1;
   uint private constant BEEP = 100;
   uint private constant PERCENT = 10000;
 
-  /**
-   * @dev This is a bitmask representation of the type of each config (either bool, address, int, uint)
-   * Each config type is represented by 4 bits. Using uint256 we can store up to 64 configs
-   * To get the type of each config, we shift the _CONFIG_TYPE to the right by 4 * configID and get the last 4 bit
-   * ie: type = (_CONFIG_TYPE >> (4 * configID)) & 0xF
-   *
-   * Below are the list of config and their types, and the index of the 4-bit that determine the type
-   *
-   * 4-bit index / ConfigID / Type
-   * ---------------------------------------------------
-   *  0 / UNSPECIFIED / Unspecified (0)
-   *  1 / SM_FUTURES_INITIAL_MARGIN / Uint (4)
-   *  2 / SM_FUTURES_MAINTENANCE_MARGIN / Uint (4)
-   *  3 / SM_FUTURES_VARIABLE_MARGIN / Uint (4)
-   *  4 / SM_OPTIONS_INITIAL_MARGIN_HIGH / Uint (4)
-   *  5 / SM_OPTIONS_INITIAL_MARGIN_LOW / Uint (4)
-   *  6 / SM_OPTIONS_MAINTENANCE_MARGIN_HIGH / Uint (4)
-   *  7 / SM_OPTIONS_MAINTENANCE_MARGIN_LOW / Uint (4)
-   *  8 / SM_OPTIONS_VARIABLE_MARGIN / Uint (4)
-   *  9 / PM_SPOT_MOVE / Uint (4)
-   * 10 / PM_VOL_MOVE_UP / Uint (4)
-   * 11 / PM_VOL_MOVE_DOWN / Uint (4)
-   * 12 / PM_SPOT_MOVE_EXTREME / Uint (4)
-   * 13 / PM_EXTREME_MOVE_DISCOUNT / Uint (4)
-   * 14 / PM_SHORT_TERM_VEGA_POWER / Uint (4)
-   * 15 / PM_LONG_TERM_VEGA_POWER / Uint (4)
-   * 16 / PM_INITIAL_MARGIN_FACTOR / Uint (4)
-   * 17 / PM_NET_SHORT_OPTION_MINIMUM / Uint (4)
-   * 18 / ADMIN_RECOVERY_ADDRESS / Address (2)
-   * 19 / FEE_SUB_ACCOUNT_ID / Address (2)
-   * 20 / PERP_FUNDING_RATE / Uint (4)
-   */
-  uint256 private constant _CONFIG_TYPE = 0x422444444444444444440;
+  ///////////////////////////////////////////////////////////////////
+  /// Config Accessors
+  ///////////////////////////////////////////////////////////////////
 
-  // ---------------- Events ----------------
-  // event ConfigScheduledEvent(CfgID indexed configID, bytes32 value);
-  // event ConfigSetEvent(CfgID indexed configID, bytes32 value);
+  function _configToInt(bytes32 v) internal pure returns (int64) {
+    return int64(uint64((uint256(v))));
+  }
 
-  // /// @notice This function should be called once in the Exchange contract constructor
-  // function _setConfigTimelock() internal {
-  //   mapping(CfgID => Rule[]) storage timelocks = state.configTimelocks;
+  function _getIntConfig(ConfigID key) internal view returns (int64, bool) {
+    ConfigValue storage c = state.config1DValues[key];
+    return (int64(uint64((uint256(c.val)))), c.isSet);
+  }
 
-  //   Rule[] storage futInitMargin = timelocks[CfgID.SM_FUTURES_INITIAL_MARGIN];
-  //   // If reducing the margin, the timelock is 0
-  //   futInitMargin.push(Rule(0, 0, 100 * PERCENT));
-  //   // If increasing the margin within 10bps, the timelock is 1 hour
-  //   futInitMargin.push(Rule(1 hours, 10 * BEEP, 0));
-  //   // If increasing the margin within 1%, the timelock is 4 hours
-  //   futInitMargin.push(Rule(4 hours, 1 * PERCENT, 0));
-  //   // If increasing the margin within 10%, the timelock is 1 day
-  //   futInitMargin.push(Rule(1 days, 10 * PERCENT, 0));
+  function _getIntConfig2D(ConfigID key, uint64 subKey) internal view returns (int64, bool) {
+    ConfigValue storage c = state.config2DValues[key][subKey];
+    return (int64(uint64((uint256(c.val)))), c.isSet);
+  }
 
-  //   timelocks[CfgID.SM_FUTURES_MAINTENANCE_MARGIN].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.SM_FUTURES_VARIABLE_MARGIN].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.SM_OPTIONS_INITIAL_MARGIN_HIGH].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.SM_OPTIONS_INITIAL_MARGIN_LOW].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.SM_OPTIONS_MAINTENANCE_MARGIN_HIGH].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.SM_OPTIONS_MAINTENANCE_MARGIN_LOW].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.SM_OPTIONS_VARIABLE_MARGIN].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.PM_SPOT_MOVE].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.PM_VOL_MOVE_UP].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.PM_VOL_MOVE_DOWN].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.PM_SHORT_TERM_VEGA_POWER].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.PM_LONG_TERM_VEGA_POWER].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.PM_INITIAL_MARGIN_FACTOR].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.PM_NET_SHORT_OPTION_MINIMUM].push(Rule(0, 0, 0));
-  //   // This config doesn't require a timelock
-  //   timelocks[CfgID.ADMIN_RECOVERY_ADDRESS].push(Rule(0, 0, 0));
-  //   timelocks[CfgID.FEE_SUB_ACCOUNT_ID].push(Rule(0, 0, 0));
-  // }
+  function _configToUint(bytes32 v) internal pure returns (uint64) {
+    return uint64((uint256(v)));
+  }
 
-  // /// @notice Schedule a config update. Afterwards, the timestamp at
-  // /// which the config is enforce is updated. This must be followed by a call
-  // /// to `setConfig` at some point in the future to actually make the config changes.
-  // ///
-  // /// @param timestamp the new system timestamp
-  // /// @param txID the new system txID
-  // /// @param key the config key
-  // /// @param value the config value in bytes32
-  // /// @param nonce the nonce of the transaction
-  // /// @param sig the signature of the transaction
-  // function scheduleConfig(
-  //   int64 timestamp,
-  //   uint64 txID,
-  //   CfgID key,
-  //   bytes32 value,
-  //   uint32 nonce,
-  //   Signature calldata sig
-  // ) external {
-  //   _setSequence(timestamp, txID);
+  function _getUintConfig(ConfigID key) internal view returns (uint64, bool) {
+    ConfigValue storage c = state.config1DValues[key];
+    return (uint64(uint256(c.val)), c.isSet);
+  }
 
-  //   // ---------- Signature Verification -----------
-  //   require(sig.signer == _getAddressCfg(CfgID.ADMIN_RECOVERY_ADDRESS), "unauthorized");
-  //   _preventReplay(hashScheduleConfig(key, value, nonce), sig);
-  //   // ------- End of Signature Verification -------
+  function _getUintConfig2D(ConfigID key, uint64 subKey) internal view returns (uint64, bool) {
+    ConfigValue storage c = state.config2DValues[key][subKey];
+    return (uint64(uint256(c.val)), c.isSet);
+  }
 
-  //   // find the timelock for this config value and update the config
-  //   int256 lockDuration = _getLockDuration(key, value);
-  //   state.scheduledConfig[key] = ScheduledConfigEntry(timestamp + lockDuration, value);
-  // }
+  function _configToAddress(bytes32 v) internal pure returns (address) {
+    return address(uint160(uint256(v)));
+  }
+
+  // https://ethereum.stackexchange.com/questions/50914/convert-bytes32-to-address
+  function _getAddressConfig(ConfigID key) internal view returns (address, bool) {
+    ConfigValue storage c = state.config1DValues[key];
+    return (address(uint160(uint256(c.val))), c.isSet);
+  }
+
+  function _getAddressConfig2D(ConfigID key, uint64 subKey) internal view returns (address, bool) {
+    ConfigValue storage c = state.config2DValues[key][subKey];
+    return (address(uint160(uint256(c.val))), c.isSet);
+  }
+
+  ///////////////////////////////////////////////////////////////////
+  /// Config APIs
+  ///////////////////////////////////////////////////////////////////
+
+  /// @notice Schedule a config update. Afterwards, the timestamp at
+  /// which the config is enforce is updated. This must be followed by a call
+  /// to `setConfig` at some point in the future to actually make the config changes.
+  ///
+  /// @param timestamp the new system timestamp
+  /// @param txID the new system txID
+  /// @param key the config key
+  /// @param subKey the config subKey, 0 for 1D config
+  /// @param value the config value in bytes32
+  /// @param sig the signature of the transaction
+  function scheduleConfig(
+    int64 timestamp,
+    uint64 txID,
+    ConfigID key,
+    uint64 subKey,
+    bytes32 value,
+    Signature calldata sig
+  ) external {
+    _setSequence(timestamp, txID);
+
+    // // ---------- Signature Verification -----------
+    // require(sig.signer == _getAddressConfig(ConfigID.ADMIN_RECOVERY_ADDRESS), "unauthorized");
+    _preventReplay(hashScheduleConfig(key, subKey, value, sig.nonce), sig);
+    // // ------- End of Signature Verification -------
+
+    ConfigSetting storage setting = state.configSettings[key];
+    require(setting.typ != ConfigType.UNSPECIFIED, "404");
+    // For 1D config settings, subKey must be 0
+    // For 2D config, there's no such restriction
+    // ie: NOT (uint256(setting.typ) % 2 == 1 && subKey == 0).
+    // We expanded the condition to make it more efficient (2 comparisons instead of 3)
+    require(uint256(setting.typ) % 2 == 0 || subKey != 0, "invalid subKey");
+
+    ConfigSchedule storage sched = setting.schedules[subKey];
+    sched.lockEndTime = timestamp + _getLockDuration(key, subKey, value);
+  }
 
   /// @notice Update a specific config. Performs check to ensure that the value
   /// is within the permissible range.
@@ -120,93 +144,138 @@ contract ConfigContract is BaseContract {
   /// @param timestamp the new system timestamp
   /// @param txID the new system txID
   /// @param key the config key
+  /// @param subKey the config sub key, for 1D config it must be 0
   /// @param value the config value in bytes32
-  /// @param nonce the nonce of the transaction
   /// @param sig the signature of the transaction
   function setConfig(
     int64 timestamp,
     uint64 txID,
-    CfgID key,
+    ConfigID key,
+    uint64 subKey,
     bytes32 value,
-    uint32 nonce,
     Signature calldata sig
   ) external {
     _setSequence(timestamp, txID);
-
     // ---------- Signature Verification -----------
-    require(sig.signer == _getAddressCfg(CfgID.ADMIN_RECOVERY_ADDRESS), "unauthorized");
-    _preventReplay(hashSetConfig(key, value, nonce), sig);
+    // (address adminRecoveryAddr, ) = _getAddressConfig(ConfigID.ADMIN_RECOVERY_ADDRESS);
+    // require(sig.signer == adminRecoveryAddr, "unauthorized");
+    _preventReplay(hashSetConfig(key, subKey, value, sig.nonce), sig);
     // ------- End of Signature Verification -------
 
-    // // find the lock duration
-    // ScheduledConfigEntry storage schedule = state.scheduledConfig[key];
-    // // any config change must be scheduled first. LockEndTime must always be positive
-    // require(schedule.lockEndTime > 0, "not scheduled");
+    ConfigSetting storage setting = state.configSettings[key];
+    ConfigType typ = setting.typ;
+    require(typ != ConfigType.UNSPECIFIED, "404");
 
-    // // If the lock duration is 0, config can be changed immediately without further check.
-    // // Otherwise, this config value must match the scheduled config value
-    // if (_getLockDuration(key, value) != 0) {
-    //   require(schedule.value == value, "mismatch scheduled");
-    //   require(schedule.lockEndTime <= timestamp, "config is locked");
-    // }
-    state.configs[key] = value;
+    // For 1D config settings, subKey must be 0
+    // For 2D config, there's no such restriction
+    // ie: NOT (uint256(setting.typ) % 2 == 1 && subKey == 0).
+    // We expanded the condition to make it more efficient (2 comparisons instead of 3)
+    require(uint256(setting.typ) % 2 != 0 || subKey != 0, "invalid 1D subKey");
+    int64 lockEndTime = setting.schedules[subKey].lockEndTime;
+    require(lockEndTime > 0 && lockEndTime <= timestamp, "not scheduled or still locked");
+
+    // 2D configs are always placed at odd indices in the enum. See ConfigID
+    if (uint(typ) % 2 == 0) {
+      mapping(uint64 => ConfigValue) storage config = state.config2DValues[key];
+      config[subKey].isSet = true;
+      config[subKey].val = value;
+    } else {
+      ConfigValue storage config = state.config1DValues[key];
+      config.isSet = true;
+      config.val = value;
+    }
+
+    // Must delete the schedule after the config is set (to prevent replays)
+    delete setting.schedules[subKey];
   }
 
-  function _getIntCfg(CfgID key) internal view returns (int256) {
-    return int256(uint256(_requireCfg(key)));
+  /// @dev Find the timelock duration in nanoseconds that corresponds to the change in value
+  /// Expect the timelocks duration should be in increasing order of delta change and timelock duration
+  function _getLockDuration(ConfigID key, uint64 subKey, bytes32 newVal) private view returns (int64) {
+    ConfigType typ = state.configSettings[key].typ;
+    require(typ != ConfigType.UNSPECIFIED, "404");
+
+    Rule[] storage rules = state.configSettings[key].rules;
+    // If there are no rules for the config setting, return 0 (no lock duration)
+    if (rules.length == 0) return 0;
+
+    // These config types are not numerical and have a fixed lock duration
+    // There should be only 1 timelock rule for these config types
+    if (typ == ConfigType.ADDRESS || typ == ConfigType.ADDRESS2D || typ == ConfigType.BOOL || typ == ConfigType.BOOL2D)
+      return rules[0].lockDuration;
+
+    if (typ == ConfigType.INT || typ == ConfigType.CENTIBEEP) {
+      (int64 oldVal, bool isSet) = _getIntConfig(key);
+      if (isSet) return _getIntConfigLockDuration(key, oldVal, _configToInt(newVal));
+      return 0;
+    } else if (typ == ConfigType.INT2D || typ == ConfigType.CENTIBEEP2D) {
+      (int64 oldVal, bool isSet) = _getIntConfig2D(key, subKey);
+      if (isSet) return _getIntConfigLockDuration(key, oldVal, _configToInt(newVal));
+      return 0;
+    } else if (typ == ConfigType.UINT) {
+      (uint64 oldVal, bool isSet) = _getUintConfig(key);
+      if (isSet) return _getUintConfigLockDuration(key, oldVal, _configToUint(newVal));
+      return 0;
+    } else if (typ == ConfigType.UINT2D) {
+      (uint64 oldVal, bool isSet) = _getUintConfig2D(key, subKey);
+      if (isSet) return _getUintConfigLockDuration(key, oldVal, _configToUint(newVal));
+      return 0;
+    }
+
+    // Should never reach here
+    require(false, "404");
+    return 0;
   }
 
-  function _getUintCfg(CfgID key) internal view returns (uint256) {
-    return uint256(_requireCfg(key));
+  /// @dev Find the timelock duration in nanoseconds that corresponds to the change in `uint` value
+  /// We expect the timelocks duration should be in increasing order of delta change and
+  /// timelock duration, ie:
+  ///    rules[i].deltaPositive < rules[i+1].deltaPositive AND rules[i].deltaNegative < rules[i+1].deltaNegative
+  /// If the change in value is not within the range of any rule, the duration of the last rule
+  /// (which is the `maximal rule`) is returned
+  ///
+  /// @param key the config key
+  /// @param oldVal the old value
+  /// @param newVal the new value
+  function _getUintConfigLockDuration(ConfigID key, uint64 oldVal, uint64 newVal) private view returns (int64) {
+    if (newVal == oldVal) return 0; // No change in value, no lock duration
+
+    Rule[] storage rules = state.configSettings[key].rules;
+    uint rulesLen = rules.length;
+
+    if (newVal < oldVal) {
+      for (uint i; i < rulesLen; ++i) {
+        if (oldVal - newVal <= rules[i].deltaNegative) return rules[i].lockDuration;
+      }
+    } else {
+      for (uint i; i < rulesLen; ++i) {
+        if (newVal - oldVal <= rules[i].deltaPositive) return rules[i].lockDuration;
+      }
+    }
+
+    return rules[rulesLen - 1].lockDuration; // Default to last timelock rule
   }
 
-  // https://ethereum.stackexchange.com/questions/50914/convert-bytes32-to-address
-  function _getAddressCfg(CfgID key) internal view returns (address) {
-    return address(uint160(uint256(_requireCfg(key))));
+  /// @dev Find the timelock duration in nanoseconds that corresponds to the change in `int` value
+  /// We expect the timelocks duration should be in increasing order of delta change and
+  /// timelock duration, ie:
+  ///    rules[i].deltaPositive < rules[i+1].deltaPositive AND rules[i].deltaNegative < rules[i+1].deltaNegative
+  /// If the change in value is not within the range of any rule, the duration of the last rule
+  /// (which is the `maximal rule`) is returned
+  ///
+  function _getIntConfigLockDuration(ConfigID key, int64 oldVal, int64 newVal) private view returns (int64) {
+    if (newVal == oldVal) return 0; // No change in value, no lock duration
+
+    Rule[] storage rules = state.configSettings[key].rules;
+    uint rulesLen = rules.length;
+
+    if (newVal < oldVal) {
+      for (uint i; i < rulesLen; ++i)
+        if (uint64(oldVal - newVal) <= rules[i].deltaNegative) return rules[i].lockDuration;
+    } else if (newVal > oldVal) {
+      for (uint i; i < rulesLen; ++i)
+        if (uint64(newVal - oldVal) <= rules[i].deltaPositive) return rules[i].lockDuration;
+    }
+    return rules[rulesLen - 1].lockDuration; // Default to last timelock rule
   }
-
-  function _getBoolCfg(CfgID key) internal view returns (bool) {
-    return uint256(_requireCfg(key)) != 0;
-  }
-
-  function _requireCfg(CfgID key) private view returns (bytes32) {
-    return state.configs[key];
-  }
-
-  // /// @dev Find the timelock duration that corresponds to the change in value
-  // /// Expect the timelocks duration should be in increasing order of delta change and timelock duration
-  // /// If the delta is out of range, revert the transaction
-  // function _getLockDuration(CfgID key, bytes32 newVal) private view returns (int256) {
-  //   // Shift the config type to the right position and mask it with 0xF (last 4 bits)
-  //   ConfigType typ = ConfigType((_CONFIG_TYPE >> (4 * uint8(key))) & 0xF);
-  //   Rule[] storage rules = state.configTimelocks[key];
-  //   if (typ == ConfigType.ADDRESS || typ == ConfigType.BOOL) {
-  //     return rules[0].lockDuration;
-  //   }
-
-  //   // TODO: add support for int config when we have one
-  //   require(typ != ConfigType.INT, "int not supported yet");
-
-  //   // Check the Uint delta
-  //   (bool positive, uint256 delta) = _getChangeDeltaUint(newVal, state.configs[key]);
-  //   for (uint256 i; i < rules.length; ++i) {
-  //     Rule storage rule = rules[i];
-  //     if ((positive && delta <= rule.deltaPositive) || (!positive && delta <= rule.deltaNegative))
-  //       return rule.lockDuration;
-  //   }
-
-  //   // delta is out of range
-  //   require(false, "out of range");
-
-  //   // Should never reach here
-  //   return 0;
-  // }
-
-  // /// @dev Get the difference between two uint values
-  // function _getChangeDeltaUint(bytes32 newVal, bytes32 oldVal) private pure returns (bool positive, uint256 diff) {
-  //   uint oldValUint = uint(oldVal);
-  //   uint newValUint = uint(newVal);
-  //   if (oldValUint > newValUint) return (false, oldValUint - newValUint);
-  //   return (true, newValUint - oldValUint);
-  // }
 }

--- a/contracts/exchange/api/signature/generated/ConfigSig.sol
+++ b/contracts/exchange/api/signature/generated/ConfigSig.sol
@@ -4,14 +4,14 @@ pragma solidity ^0.8.20;
 
 import "../../../types/DataStructure.sol";
 
-bytes32 constant _SCHEDULE_CONFIG_H = keccak256("ScheduleConfig(uint8 key,bytes32 value,uint32 nonce)");
+bytes32 constant _SCHEDULE_CONFIG_H = keccak256("ScheduleConfig(uint8 key,uint64 subKey,bytes32 value,uint32 nonce)");
 
-function hashScheduleConfig(ConfigID key, bytes32 value, uint32 nonce) pure returns (bytes32) {
-  return keccak256(abi.encode(_SCHEDULE_CONFIG_H, uint8(key), value, nonce));
+function hashScheduleConfig(ConfigID key, uint64 subKey, bytes32 value, uint32 nonce) pure returns (bytes32) {
+  return keccak256(abi.encode(_SCHEDULE_CONFIG_H, uint8(key), subKey, value, nonce));
 }
 
-bytes32 constant _SET_CONFIG_H = keccak256("SetConfig(uint8 key,bytes32 value,uint32 nonce)");
+bytes32 constant _SET_CONFIG_H = keccak256("SetConfig(uint8 key,uint64 subKey,bytes32 value,uint32 nonce)");
 
-function hashSetConfig(ConfigID key, bytes32 value, uint32 nonce) pure returns (bytes32) {
-  return keccak256(abi.encode(_SET_CONFIG_H, uint8(key), value, nonce));
+function hashSetConfig(ConfigID key, uint64 subKey, bytes32 value, uint32 nonce) pure returns (bytes32) {
+  return keccak256(abi.encode(_SET_CONFIG_H, uint8(key), subKey, value, nonce));
 }

--- a/test/foundry/Base.t.sol
+++ b/test/foundry/Base.t.sol
@@ -74,8 +74,8 @@ contract BaseTest is Test {
   /// @dev Deploys {GRVTExchange} contract
   function deployGRVTExchange() internal {
     grvtExchange = new GRVTExchange();
-    bytes32[] memory _initialConfig = new bytes32[](0);
-    grvtExchange.initialize(_initialConfig);
+    // We don't use this way in prod. When we use the openzeppelin plugin - this is called internally
+    grvtExchange.initialize();
     vm.label({account: address(grvtExchange), newLabel: "GRVTExchange"});
   }
 


### PR DESCRIPTION
Add these config APIs
- `scheduleConfig`
- `setConfig`

Each config must be scheduled. We will compute the necessary timelock for this scheduled config. 
After the timelock has passed, the operator can call `setConfig` to enact the change. Any attempt to call `setConfig` will be rejected.

TODO:
- [ ] Require the signer for both these API to be an admin address 
- [ ] Add tests
- [ ] Add default values for the configs