### PR TITLE
asset: add test for asset encoding

### DIFF
--- a/contracts/exchange/types/DataStructure.sol
+++ b/contracts/exchange/types/DataStructure.sol
@@ -30,7 +30,10 @@ enum Kind {
   PERPS,
   FUTURES,
   CALL,
-  PUT
+  PUT,
+  SPOT,
+  SETTLEMENT,
+  RATE
 }
 
 enum Currency {

--- a/contracts/exchange/util/Asset.sol
+++ b/contracts/exchange/util/Asset.sol
@@ -13,47 +13,47 @@ struct Asset {
 
 /// @dev Parse the assetID into its components
 ///
-/// LSB                                                                                           MSB
-///    ------------------------------------------------------------------------------------------
-/// 0 | Kind (1B) | Underlying (1B) | Quote (1B) | Reserved (1B) | Expiration (8B) | Strike (8B)|
-///   ------------------------------------------------------------------------------------------
+/// LSB                                                                                                            MSB
+///     +--------------------------------------------------------------------------------------------------------+
+///   0 | Kind (1B) | Underlying (1B) | Quote (1B) | Reserved (1B) | Expiration (8B) | Strike (8B)| Zero Padding | 255
+///     +-----------------------------------------------------------------------------------------+--------------+
 function parseAssetID(bytes32 assetID) pure returns (Asset memory) {
-  uint id = uint256(assetID);
+  uint id = uint(assetID);
   return
     Asset(
       Kind(id & 0xFF),
       Currency((id >> 8) & 0xFF), // Underlying
       Currency((id >> 16) & 0xFF), // Quote
-      uint64((id >> 32) & 0xFFFFFFFF), // Expiration
-      uint64((id >> 64) & 0xFFFFFFFF) // Strike Price
+      uint64((id >> 32) & 0xFFFFFFFFFFFFFFFF), // Expiration
+      uint64((id >> 96) & 0xFFFFFFFFFFFFFFFF) // Strike Price
     );
 }
 
-function assetToID(Asset memory asset) pure returns (uint256) {
+function assetToID(Asset memory asset) pure returns (uint) {
   return
-    uint256(asset.kind) |
-    (uint256(asset.underlying) << 8) |
-    (uint256(asset.quote) << 16) |
-    (uint256(asset.expiration) << 32) |
-    (uint256(asset.strikePrice) << 64);
+    uint(asset.kind) |
+    (uint(asset.underlying) << 8) |
+    (uint(asset.quote) << 16) |
+    (uint(asset.expiration) << 32) |
+    (uint(asset.strikePrice) << 96);
 }
 
 function assetGetKind(bytes32 assetID) pure returns (Kind) {
-  return Kind(uint256(assetID) & 0xFF);
+  return Kind(uint(assetID) & 0xFF);
 }
 
 function assetGetUnderlying(bytes32 assetID) pure returns (Currency) {
-  return Currency((uint256(assetID) >> 8) & 0xFF);
+  return Currency((uint(assetID) >> 8) & 0xFF);
 }
 
 function assetGetQuote(bytes32 assetID) pure returns (Currency) {
-  return Currency((uint256(assetID) >> 16) & 0xFF);
+  return Currency((uint(assetID) >> 16) & 0xFF);
 }
 
 function assetGetExpiration(bytes32 assetID) pure returns (uint64) {
-  return uint64((uint256(assetID) >> 32) & 0xFFFFFFFF);
+  return uint64((uint(assetID) >> 32) & 0xFFFFFFFFFFFFFFFF);
 }
 
 function assetGetStrikePrice(bytes32 assetID) pure returns (uint64) {
-  return uint64((uint256(assetID) >> 64) & 0xFFFFFFFF);
+  return uint64((uint(assetID) >> 96) & 0xFFFFFFFFFFFFFFFF);
 }

--- a/test/foundry/api/APIBase.t.sol
+++ b/test/foundry/api/APIBase.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
 import "../../../lib/forge-std/src/Test.sol";

--- a/test/foundry/api/SubAccountContract.t.sol
+++ b/test/foundry/api/SubAccountContract.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.0 <0.9.0;
 
 import "../../../lib/forge-std/src/Test.sol";

--- a/test/foundry/trade/ManyLegOneMaker.t.sol
+++ b/test/foundry/trade/ManyLegOneMaker.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
 import "../../../lib/forge-std/src/Test.sol";

--- a/test/foundry/trade/TradeBase.t.sol
+++ b/test/foundry/trade/TradeBase.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
 
 import "../../../lib/forge-std/src/Test.sol";

--- a/test/foundry/types/Types.sol
+++ b/test/foundry/types/Types.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.0 <0.9.0;
 
 struct Users {

--- a/test/foundry/util/Asset.t.sol
+++ b/test/foundry/util/Asset.t.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../../contracts/exchange/util/Asset.sol";
+import "../../../contracts/exchange/types/DataStructure.sol";
+import "forge-std/console.sol";
+
+struct AssetTestCase {
+  Asset asset;
+  string name;
+  bytes32 expectedID;
+}
+
+contract AssetHelperTest is Test {
+  function testParseAssetID() public {
+    AssetTestCase[8] memory testCases;
+    uint id = 0;
+
+    // Empty
+    testCases[id] = AssetTestCase({
+      name: "ETH USDC Perp",
+      asset: Asset({
+        kind: Kind.UNSPECIFIED,
+        underlying: Currency.UNSPECIFIED,
+        quote: Currency.UNSPECIFIED,
+        expiration: uint64(0),
+        strikePrice: uint64(0)
+      }),
+      expectedID: bytes32(uint(0x0000000000000000000000000000000000000000000000000000000000000000))
+    });
+    id++;
+
+    // Perp
+    testCases[id] = AssetTestCase({
+      name: "ETH USDC Perp",
+      asset: Asset({
+        kind: Kind.PERPS,
+        underlying: Currency.ETH,
+        quote: Currency.USDC,
+        expiration: uint64(0),
+        strikePrice: uint64(0)
+      }),
+      expectedID: bytes32(uint(0x0000000000000000000000000000000000000000000000000000000000020401))
+    });
+    id++;
+
+    // Future
+    testCases[id] = AssetTestCase({
+      name: "BTC USDT Fut 20Oct23",
+      asset: Asset({
+        kind: Kind.FUTURES,
+        underlying: Currency.BTC,
+        quote: Currency.USDT,
+        expiration: uint64(1697801813_000_000_000),
+        strikePrice: uint64(0)
+      }),
+      expectedID: bytes32(0x0000000000000000000000000000000000000000178fcdc0eae1120000030502)
+    });
+    id++;
+
+    // Call
+    testCases[id] = AssetTestCase({
+      name: "ETH USDC Call 20Oct23 4123",
+      asset: Asset({
+        kind: Kind.CALL,
+        underlying: Currency.ETH,
+        quote: Currency.USDC,
+        expiration: uint64(1697801813_000_000_000),
+        strikePrice: uint64(4123_000_000)
+      }),
+      expectedID: bytes32(0x00000000000000000000000000000000f5bffcc0178fcdc0eae1120000020403)
+    });
+    id++;
+
+    // Put
+    testCases[id] = AssetTestCase({
+      name: "USDT BTC Put 20Oct23 4123",
+      asset: Asset({
+        kind: Kind.PUT,
+        quote: Currency.BTC,
+        underlying: Currency.USDT,
+        expiration: uint64(1697801813_000_000_000),
+        strikePrice: uint64(4123_000_000_000)
+      }),
+      expectedID: bytes32(0x000000000000000000000000000003bff5f34e00178fcdc0eae1120000050304)
+    });
+    id++;
+
+    // Spot
+    testCases[id] = AssetTestCase({
+      name: "USDC Spot",
+      asset: Asset({
+        kind: Kind.SPOT,
+        underlying: Currency.USDC,
+        quote: Currency.UNSPECIFIED,
+        expiration: uint64(0),
+        strikePrice: uint64(0)
+      }),
+      expectedID: bytes32(0x0000000000000000000000000000000000000000000000000000000000000205)
+    });
+    id++;
+
+    // Settlement
+    testCases[id] = AssetTestCase({
+      name: "ETH Sett 20Oct23",
+      asset: Asset({
+        kind: Kind.SETTLEMENT,
+        underlying: Currency.ETH,
+        quote: Currency.USD,
+        expiration: uint64(1697801813_000_000_000),
+        strikePrice: uint64(0)
+      }),
+      expectedID: bytes32(0x0000000000000000000000000000000000000000178fcdc0eae1120000010406)
+    });
+    id++;
+
+    // Rate
+    testCases[id] = AssetTestCase({
+      name: "ETH Rate 20Oct23",
+      asset: Asset({
+        kind: Kind.RATE,
+        underlying: Currency.ETH,
+        quote: Currency.USD,
+        expiration: uint64(1697801813_000_000_000),
+        strikePrice: uint64(0)
+      }),
+      expectedID: bytes32(0x0000000000000000000000000000000000000000178fcdc0eae1120000010407)
+    });
+    id++;
+
+    for (uint i = 0; i < testCases.length; i++) {
+      AssetTestCase memory tc = testCases[i];
+      Asset memory asset = tc.asset;
+      bytes32 expectedID = tc.expectedID;
+      bytes32 actualID = bytes32(assetToID(asset));
+      assertEq(expectedID, actualID, concat(tc.name, " ids mismatch"));
+      assertEq(uint(asset.kind), uint(assetGetKind(actualID)), concat(tc.name, " kind mismatch"));
+      assertEq(uint(asset.underlying), uint(assetGetUnderlying(actualID)), concat(tc.name, " underlying mismatch"));
+      assertEq(uint(asset.quote), uint(assetGetQuote(actualID)), concat(tc.name, " quote mismatch"));
+      assertEq(asset.expiration, assetGetExpiration(actualID), concat(tc.name, " expiration mismatch"));
+      assertEq(asset.strikePrice, assetGetStrikePrice(actualID), concat(tc.name, " strike price mismatch"));
+    }
+  }
+
+  function concat(string memory a, string memory b) public pure returns (string memory) {
+    return string(abi.encodePacked(a, b));
+  }
+}


### PR DESCRIPTION
Replicate tests from https://github.com/gravity-technologies/platform/blob/e10392aa02af8ad4dbc3bae4b4064def7ced6ab7/backend/lib/markets/aerondto/primitives/asset_test.go#L15