### PR TITLE
allow transfering token without any signature

### DIFF
--- a/contracts/exchange/api/TransferContract.sol
+++ b/contracts/exchange/api/TransferContract.sol
@@ -76,7 +76,8 @@ abstract contract TransferContract is TradeContract {
     require(acc.onboardedWithdrawalAddresses[recipient], "invalid withdrawal address");
 
     // ---------- Signature Verification -----------
-    _preventReplay(hashWithdrawal(fromAccID, recipient, currency, numTokens, sig.nonce), sig);
+    // FIXME: disable for testnet testing
+    // _preventReplay(hashWithdrawal(fromAccID, recipient, currency, numTokens, sig.nonce), sig);
     // ------- End of Signature Verification -------
 
     // TODO: charge withdrawal fee


### PR DESCRIPTION
This is to support depositing and transferring arbitrary amount of token, to support our closed beta launch.


THIS HAS TO BE REMOVED BEFORE OPEN BETA!!!