### PR TITLE
Fix 2 bugs in perps funding

### DIFF
--- a/contracts/exchange/api/FundingAndSettlement.sol
+++ b/contracts/exchange/api/FundingAndSettlement.sol
@@ -18,7 +18,8 @@ contract FundingAndSettlement is BaseContract {
 
   function _fundPerp(SubAccount storage sub) internal {
     // Skip Funding, since it has already been applied
-    if (sub.lastAppliedFundingTimestamp == state.prices.fundingTime) {
+    int64 fundingTime = state.prices.fundingTime;
+    if (sub.lastAppliedFundingTimestamp == fundingTime) {
       return;
     }
 
@@ -29,8 +30,6 @@ contract FundingAndSettlement is BaseContract {
     BI memory fundingPayment;
 
     bytes32[] storage keys = perps.keys;
-    int64 fundingTime = state.prices.fundingTime;
-    int64 newSpotBalance = int64(sub.spotBalances[quoteCurrency]);
     uint len = keys.length;
     for (uint i; i < len; ++i) {
       bytes32 assetID = keys[i];
@@ -47,9 +46,8 @@ contract FundingAndSettlement is BaseContract {
           .scale(qdec)
       );
       perp.lastAppliedFundingIndex = latestFundingIndex;
-      newSpotBalance += fundingPayment.toInt64(qdec);
     }
-    sub.spotBalances[quoteCurrency] = newSpotBalance;
+    sub.spotBalances[quoteCurrency] += fundingPayment.toInt64(qdec);
     sub.lastAppliedFundingTimestamp = fundingTime;
   }
 

--- a/contracts/exchange/api/OracleContract.sol
+++ b/contracts/exchange/api/OracleContract.sol
@@ -132,10 +132,8 @@ contract OracleContract is ConfigContract {
       PriceEntry calldata entry = prices[i];
       BI memory markPrice = _requireMarkPriceBI(entry.assetID);
       // Funding (10 & 11.1): Computing the new funding index (a way to do lazy funding payments on-demand)
-      int256 delta = markPrice.mul(BI(entry.value, CENTIBEEP_DECIMALS)).div(BI(TIME_FACTOR, 0)).toInt256(
-        PRICE_DECIMALS
-      );
-      fundings[entry.assetID] += int64(delta);
+      int64 delta = markPrice.mul(BI(entry.value, CENTIBEEP_DECIMALS)).div(BI(TIME_FACTOR, 0)).toInt64(PRICE_DECIMALS);
+      fundings[entry.assetID] += delta;
     }
     state.prices.fundingTime = sig.expiration;
   }

--- a/contracts/exchange/api/TransferContract.sol
+++ b/contracts/exchange/api/TransferContract.sol
@@ -40,7 +40,7 @@ abstract contract TransferContract is TradeContract {
     // the token required for deposit
 
     int64 numTokensSigned = int64(numTokens);
-    require(numTokensSigned >= 0, "invalid withdrawal amount");
+    require(numTokensSigned >= 0, "invalid deposit amount");
 
     uint256 fundExchangeAmount = scaleToERC20Amount(currency, numTokensSigned);
 
@@ -219,6 +219,7 @@ abstract contract TransferContract is TradeContract {
 
     SubAccount storage toSubAcc = _requireSubAccount(toSubID);
     _requireSubAccountUnderAccount(toSubAcc, toAccID);
+    _fundAndSettle(toSubAcc);
     toSubAcc.spotBalances[currency] += numTokens;
   }
 

--- a/deploy/deployupgradabletest.ts
+++ b/deploy/deployupgradabletest.ts
@@ -1,0 +1,52 @@
+import { execSync } from "child_process"
+import { ethers } from "ethers"
+import path from "path"
+import { L2SharedBridge } from "../lib/era-contracts/l2-contracts/typechain/L2SharedBridge"
+import { L2SharedBridgeFactory } from "../lib/era-contracts/l2-contracts/typechain/L2SharedBridgeFactory"
+import { L2TokenInfo } from "./testutil"
+import { LOCAL_RICH_WALLETS, deployContractUpgradable, getWallet } from "./utils"
+
+let l2SharedBridgeAsL1Bridge: L2SharedBridge
+
+// Deploy Upgradable Script
+export default async function () {
+  const contractArtifactName = "GRVTExchangeTest"
+  const exchangeContract = await deployContractUpgradable(contractArtifactName)
+  const [deployerWallet, governorWallet, l1BridgeWallet] = LOCAL_RICH_WALLETS.slice(0, 3).map((w) =>
+    getWallet(w.privateKey)
+  )
+
+  // setup L2SharedBridge and BeaconProxy for L2StandardERC20 for deposit and withdrawal
+  // DO NOT update the salt as it would change the deployed contract address, which is fixed across runs and
+  // hardcoded in risk RTF tests
+  const result = execSync(
+    [
+      "npx",
+      "hardhat",
+      "deploy-erc20-test-setup",
+      "--deployer-private-key",
+      deployerWallet.privateKey,
+      "--governor-private-key",
+      governorWallet.privateKey,
+      "--l1-bridge-private-key",
+      l1BridgeWallet.privateKey,
+      "--salt",
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("test")),
+    ].join(" "),
+    { cwd: path.resolve("lib/era-contracts/l2-contracts"), stdio: "pipe" }
+  )
+
+  const l2SharedBridgeAddress = result.toString().trim()
+  const l2SharedBridge = L2SharedBridgeFactory.connect(l2SharedBridgeAddress, deployerWallet)
+
+  console.log(`Deployed L2SharedBridge at ${l2SharedBridgeAddress}`)
+  for (const token in L2TokenInfo) {
+    const tokenAddress = await l2SharedBridge.l2TokenAddress(L2TokenInfo[token].l1Token)
+    console.log(`Token ${token} has L2 address ${tokenAddress}`)
+  }
+
+  // exchange address is required before ERC20 can be deployed
+  await (await l2SharedBridge.setExchangeAddress(exchangeContract.address)).wait()
+
+  l2SharedBridgeAsL1Bridge = L2SharedBridgeFactory.connect(l2SharedBridgeAddress, l1BridgeWallet)
+}

--- a/deploy/testutil.ts
+++ b/deploy/testutil.ts
@@ -1,0 +1,34 @@
+
+export const L2TokenInfo: {
+  [key: string]: {
+    l1Token: string
+    erc20Decimals: number
+    exchangeDecimals: number
+    name: string
+  }
+} = {
+  USDC: {
+    l1Token: "0x1111000000000000000000000000000000001110",
+    erc20Decimals: 6,
+    exchangeDecimals: 6,
+    name: "USD Coin",
+  },
+  USDT: {
+    l1Token: "0x1111000000000000000000000000000000001111",
+    erc20Decimals: 6,
+    exchangeDecimals: 6,
+    name: "Tether USD",
+  },
+  ETH: {
+    l1Token: "0x1111000000000000000000000000000000001112",
+    erc20Decimals: 18,
+    exchangeDecimals: 9,
+    name: "Ether",
+  },
+  BTC: {
+    l1Token: "0x1111000000000000000000000000000000001113",
+    erc20Decimals: 8,
+    exchangeDecimals: 9,
+    name: "Wrapped Bitcoin",
+  },
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "sizer": "forge build --sizes",
     "deploy": "hardhat deploy-zksync --script deploy.ts",
     "deploy:upgradable": "hardhat deploy-zksync --script deployupgradable.ts",
+    "deploy:upgradabletest": "hardhat deploy-zksync --script deployupgradabletest.ts",
     "deploy:upgrade": "hardhat deploy-zksync --script upgrade.ts",
     "execute": "hardhat deploy-zksync --script",
     "clean": "hardhat clean",

--- a/test/engine/TestEngine.test.ts
+++ b/test/engine/TestEngine.test.ts
@@ -9,6 +9,7 @@ import { L2SharedBridgeFactory } from "../../lib/era-contracts/l2-contracts/type
 import { L2SharedBridge } from "../../lib/era-contracts/l2-contracts/typechain/L2SharedBridge"
 import { execSync } from "child_process"
 import path from "path"
+import { L2TokenInfo } from "../../deploy/testutil"
 
 const gasLimit = 2100000000
 const testDir = "/test/engine/testfixtures/"
@@ -152,40 +153,6 @@ async function validateTest(test: TestCase, exchangeContract: Contract, w1: Wall
   }
 
   return
-}
-
-const L2TokenInfo: {
-  [key: string]: {
-    l1Token: string
-    erc20Decimals: number
-    exchangeDecimals: number
-    name: string
-  }
-} = {
-  USDC: {
-    l1Token: "0x1111000000000000000000000000000000001110",
-    erc20Decimals: 6,
-    exchangeDecimals: 6,
-    name: "USD Coin",
-  },
-  USDT: {
-    l1Token: "0x1111000000000000000000000000000000001111",
-    erc20Decimals: 6,
-    exchangeDecimals: 6,
-    name: "Tether USD",
-  },
-  ETH: {
-    l1Token: "0x1111000000000000000000000000000000001112",
-    erc20Decimals: 18,
-    exchangeDecimals: 9,
-    name: "Ether",
-  },
-  BTC: {
-    l1Token: "0x1111000000000000000000000000000000001113",
-    erc20Decimals: 8,
-    exchangeDecimals: 9,
-    name: "Wrapped Bitcoin",
-  },
 }
 
 function isDeposit(step: TestStep) {


### PR DESCRIPTION
- Perps funding is double counted in the for loop
- Missing a call to fund perps before transferring from main to sub account

# Test
Will be added later, but I have verified that with this change we can process all the transactions in testnet (roughly 200k of them)