### PR TITLE
Add AssertionContract

### DIFF
--- a/contracts/exchange/GRVTExchange.sol
+++ b/contracts/exchange/GRVTExchange.sol
@@ -7,6 +7,7 @@ import "./api/WalletRecoveryContract.sol";
 import "./api/OracleContract.sol";
 import "./api/TransferContract.sol";
 import "./api/LiquidationContract.sol";
+import "./api/AssertionContract.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract GRVTExchange is
@@ -16,7 +17,8 @@ contract GRVTExchange is
   WalletRecoveryContract,
   OracleContract,
   TransferContract,
-  LiquidationContract
+  LiquidationContract,
+  AssertionContract
 {
   function initialize() public initializer {
     __ReentrancyGuard_init();

--- a/contracts/exchange/GRVTExchangeTest.sol
+++ b/contracts/exchange/GRVTExchangeTest.sol
@@ -48,72 +48,6 @@ contract GRVTExchangeTest is GRVTExchange {
       });
   }
 
-  function isAllAccountExists(address[] calldata accountIDs) public view returns (bool) {
-    for (uint256 i = 0; i < accountIDs.length; i++) {
-      if (state.accounts[accountIDs[i]].id == address(0)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  function getAccountSpotBalance(address accID, Currency currency) public view returns (int64) {
-    Account storage account = state.accounts[accID];
-    return account.spotBalances[currency];
-  }
-
-  function isRecoveryAddress(address id, address signer, address recoveryAddress) public view returns (bool) {
-    Account storage account = state.accounts[id];
-    return addressExists(account.recoveryAddresses[signer], recoveryAddress);
-  }
-
-  function isOnboardedWithdrawalAddress(address id, address withdrawalAddress) public view returns (bool) {
-    Account storage account = state.accounts[id];
-    return account.onboardedWithdrawalAddresses[withdrawalAddress];
-  }
-
-  function getAccountOnboardedTransferAccount(address accID, address transferAccount) public view returns (bool) {
-    Account storage account = state.accounts[accID];
-    return account.onboardedTransferAccounts[transferAccount];
-  }
-
-  function getSignerPermission(address id, address signer) public view returns (uint64) {
-    Account storage account = state.accounts[id];
-    return account.signers[signer];
-  }
-
-  function getSessionValue(address sessionKey) public view returns (address, int64) {
-    return (state.sessions[sessionKey].subAccountSigner, state.sessions[sessionKey].expiry);
-  }
-
-  function getConfig2D(ConfigID id, bytes32 subKey) public view returns (bytes32) {
-    ConfigValue storage config = state.config2DValues[id][subKey];
-    if (config.isSet) {
-      return config.val;
-    }
-    return state.config2DValues[id][DEFAULT_CONFIG_ENTRY].val;
-  }
-
-  function config1DIsSet(ConfigID id) public view returns (bool) {
-    return state.config1DValues[id].isSet;
-  }
-
-  function config2DIsSet(ConfigID id) public view returns (bool) {
-    return state.config2DValues[id][DEFAULT_CONFIG_ENTRY].isSet;
-  }
-
-  function getConfig1D(ConfigID id) public view returns (bytes32) {
-    return state.config1DValues[id].val;
-  }
-
-  function getConfigSchedule(ConfigID id, bytes32 subKey) public view returns (int64) {
-    return state.configSettings[id].schedules[subKey].lockEndTime;
-  }
-
-  function isConfigScheduleAbsent(ConfigID id, bytes32 subKey) public view returns (bool) {
-    return state.configSettings[id].schedules[subKey].lockEndTime == 0;
-  }
-
   function getSubAccountResult(uint64 id) public view returns (SubAccountResult memory) {
     SubAccount storage subAccount = state.subAccounts[id];
     return
@@ -126,52 +60,5 @@ contract GRVTExchangeTest is GRVTExchange {
         quoteCurrency: subAccount.quoteCurrency,
         lastAppliedFundingTimestamp: subAccount.lastAppliedFundingTimestamp
       });
-  }
-
-  function getSubAccSignerPermission(uint64 id, address signer) public view returns (uint64) {
-    SubAccount storage subAccount = state.subAccounts[id];
-    return subAccount.signers[signer];
-  }
-
-  function getFundingIndex(bytes32 assetID) public view returns (int64) {
-    return state.prices.fundingIndex[assetID];
-  }
-
-  function getFundingTime() public view returns (int64) {
-    return state.prices.fundingTime;
-  }
-
-  function getMarkPrice(bytes32 assetID) public view returns (uint64, bool) {
-    return _getMarkPrice9Decimals(assetID);
-  }
-
-  function getSettlementPrice(bytes32 assetID) public view returns (uint64, bool) {
-    SettlementPriceEntry storage entry = state.prices.settlement[assetID];
-    return (entry.value, entry.isSet);
-  }
-
-  function getInterestRate(bytes32 assetID) public view returns (int32) {
-    return state.prices.interest[assetID];
-  }
-
-  function getSubAccountValue(uint64 subAccountID) public view returns (int64) {
-    SubAccount storage sub = _requireSubAccount(subAccountID);
-    uint64 quoteDecimals = _getBalanceDecimal(sub.quoteCurrency);
-    return _getSubAccountUsdValue(sub).toInt64(quoteDecimals);
-  }
-
-  function getSubAccountPosition(
-    uint64 subAccountID,
-    bytes32 assetID
-  ) public view returns (bool found, int64 balance, int64 lastAppliedFundingIndex) {
-    SubAccount storage sub = _requireSubAccount(subAccountID);
-    PositionsMap storage posmap = _getPositionCollection(sub, assetGetKind(assetID));
-    Position storage pos = posmap.values[assetID];
-    return (pos.id != 0x0, pos.balance, pos.lastAppliedFundingIndex);
-  }
-
-  function getSubAccountSpotBalance(uint64 subAccountID, Currency currency) public view returns (int64) {
-    SubAccount storage sub = _requireSubAccount(subAccountID);
-    return sub.spotBalances[currency];
   }
 }

--- a/contracts/exchange/api/AssertionContract.sol
+++ b/contracts/exchange/api/AssertionContract.sol
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "./RiskCheck.sol";
+import "./ConfigContract.sol";
+
+struct SpotBalanceAssertion {
+  Currency currency;
+  int64 balance;
+}
+
+struct RecoveryAddressAssertion {
+  address signer;
+  address[] recoveryAddresses;
+}
+
+struct PositionAssertion {
+  bytes32 assetId;
+  int64 balance;
+  int64 lastAppliedFundingIndex;
+}
+
+struct PositionsMapAssertion {
+  PositionAssertion[] positions;
+}
+
+struct AccountAssertion {
+  address id;
+  uint64 multiSigThreshold;
+  uint64 adminCount;
+  uint64[] subAccounts;
+  SpotBalanceAssertion[] spotBalances;
+  RecoveryAddressAssertion[] recoveryAddresses;
+  address[] onboardedWithdrawalAddresses;
+  address[] onboardedTransferAccounts;
+  address[] signers;
+  uint64[] signerPermissions;
+}
+
+struct SubAccountAssertion {
+  uint64 id;
+  uint64 adminCount;
+  uint64 signerCount;
+  address accountID;
+  MarginType marginType;
+  Currency quoteCurrency;
+  int64 lastAppliedFundingTimestamp;
+  SpotBalanceAssertion[] spotBalances;
+  PositionsMapAssertion options;
+  PositionsMapAssertion futures;
+  PositionsMapAssertion perps;
+  address[] signers;
+  uint64[] signerPermissions;
+}
+
+contract AssertionContract is ConfigContract, RiskCheck {
+  using BIMath for BI;
+
+  function assertIsAllAccountExists(address[] calldata accountIDs, bool expected) public view {
+    bool result = isAllAccountExists(accountIDs);
+    require(result == expected, "AssertionContract: isAllAccountExists assertion failed");
+  }
+
+  function assertAccountSpotBalance(address accID, Currency currency, int64 expected) public view {
+    int64 balance = getAccountSpotBalance(accID, currency);
+    require(balance == expected, "AssertionContract: accountSpotBalance assertion failed");
+  }
+
+  function assertIsRecoveryAddress(address id, address signer, address recoveryAddress, bool expected) public view {
+    bool result = isRecoveryAddress(id, signer, recoveryAddress);
+    require(result == expected, "AssertionContract: isRecoveryAddress assertion failed");
+  }
+
+  function assertIsOnboardedWithdrawalAddress(address id, address withdrawalAddress, bool expected) public view {
+    bool result = isOnboardedWithdrawalAddress(id, withdrawalAddress);
+    require(result == expected, "AssertionContract: isOnboardedWithdrawalAddress assertion failed");
+  }
+
+  function assertAccountOnboardedTransferAccount(address accID, address transferAccount, bool expected) public view {
+    bool result = getAccountOnboardedTransferAccount(accID, transferAccount);
+    require(result == expected, "AssertionContract: accountOnboardedTransferAccount assertion failed");
+  }
+
+  function assertSignerPermission(address id, address signer, uint64 expected) public view {
+    uint64 permission = getSignerPermission(id, signer);
+    require(permission == expected, "AssertionContract: signerPermission assertion failed");
+  }
+
+  function assertSessionValue(address sessionKey, address expectedSigner, int64 expectedExpiry) public view {
+    (address signer, int64 expiry) = getSessionValue(sessionKey);
+    require(signer == expectedSigner && expiry == expectedExpiry, "AssertionContract: sessionValue assertion failed");
+  }
+
+  function assertConfig2D(ConfigID id, bytes32 subKey, bytes32 expected) public view {
+    bytes32 result = getConfig2D(id, subKey);
+    require(result == expected, "AssertionContract: config2D assertion failed");
+  }
+
+  function assertConfig1DIsSet(ConfigID id, bool expected) public view {
+    bool result = config1DIsSet(id);
+    require(result == expected, "AssertionContract: config1DIsSet assertion failed");
+  }
+
+  function assertConfig2DIsSet(ConfigID id, bool expected) public view {
+    bool result = config2DIsSet(id);
+    require(result == expected, "AssertionContract: config2DIsSet assertion failed");
+  }
+
+  function assertConfig1D(ConfigID id, bytes32 expected) public view {
+    bytes32 result = getConfig1D(id);
+    require(result == expected, "AssertionContract: config1D assertion failed");
+  }
+
+  function assertConfigSchedule(ConfigID id, bytes32 subKey, int64 expected) public view {
+    int64 result = getConfigSchedule(id, subKey);
+    require(result == expected, "AssertionContract: configSchedule assertion failed");
+  }
+
+  function assertIsConfigScheduleAbsent(ConfigID id, bytes32 subKey, bool expected) public view {
+    bool result = isConfigScheduleAbsent(id, subKey);
+    require(result == expected, "AssertionContract: isConfigScheduleAbsent assertion failed");
+  }
+
+  function assertSubAccSignerPermission(uint64 id, address signer, uint64 expected) public view {
+    uint64 permission = getSubAccSignerPermission(id, signer);
+    require(permission == expected, "AssertionContract: subAccSignerPermission assertion failed");
+  }
+
+  function assertFundingIndex(bytes32 assetID, int64 expected) public view {
+    int64 index = getFundingIndex(assetID);
+    require(index == expected, "AssertionContract: fundingIndex assertion failed");
+  }
+
+  function assertFundingTime(int64 expected) public view {
+    int64 time = getFundingTime();
+    require(time == expected, "AssertionContract: fundingTime assertion failed");
+  }
+
+  function assertMarkPrice(bytes32 assetID, uint64 expectedPrice, bool expectedIsSet) public view {
+    (uint64 price, bool isSet) = getMarkPrice(assetID);
+    require(price == expectedPrice && isSet == expectedIsSet, "AssertionContract: markPrice assertion failed");
+  }
+
+  function assertSettlementPrice(bytes32 assetID, uint64 expectedValue, bool expectedIsSet) public view {
+    (uint64 value, bool isSet) = getSettlementPrice(assetID);
+    require(value == expectedValue && isSet == expectedIsSet, "AssertionContract: settlementPrice assertion failed");
+  }
+
+  function assertInterestRate(bytes32 assetID, int32 expected) public view {
+    int32 rate = getInterestRate(assetID);
+    require(rate == expected, "AssertionContract: interestRate assertion failed");
+  }
+
+  function assertSubAccountValue(uint64 subAccountID, int64 expected) public view {
+    int64 value = getSubAccountValue(subAccountID);
+    require(value == expected, "AssertionContract: subAccountValue assertion failed");
+  }
+
+  function assertSubAccountPosition(
+    uint64 subAccountID,
+    bytes32 assetID,
+    bool expectedFound,
+    int64 expectedBalance,
+    int64 expectedLastAppliedFundingIndex
+  ) public view {
+    (bool found, int64 balance, int64 lastAppliedFundingIndex) = getSubAccountPosition(subAccountID, assetID);
+    require(
+      found == expectedFound &&
+        balance == expectedBalance &&
+        lastAppliedFundingIndex == expectedLastAppliedFundingIndex,
+      "AssertionContract: subAccountPosition assertion failed"
+    );
+  }
+
+  function assertSubAccountSpotBalance(uint64 subAccountID, Currency currency, int64 expected) public view {
+    int64 balance = getSubAccountSpotBalance(subAccountID, currency);
+    require(balance == expected, "AssertionContract: subAccountSpotBalance assertion failed");
+  }
+
+  function assertAccount(address accountId, AccountAssertion calldata assertion) public view {
+    Account storage account = state.accounts[accountId];
+
+    require(account.id == assertion.id, "Account ID mismatch");
+    require(account.multiSigThreshold == assertion.multiSigThreshold, "MultiSigThreshold mismatch");
+    require(account.adminCount == assertion.adminCount, "AdminCount mismatch");
+    require(
+      keccak256(abi.encodePacked(account.subAccounts)) == keccak256(abi.encodePacked(assertion.subAccounts)),
+      "SubAccounts mismatch"
+    );
+
+    for (uint i = 0; i < assertion.spotBalances.length; i++) {
+      require(
+        account.spotBalances[assertion.spotBalances[i].currency] == assertion.spotBalances[i].balance,
+        "SpotBalance mismatch"
+      );
+    }
+
+    for (uint i = 0; i < assertion.recoveryAddresses.length; i++) {
+      address[] storage recoveryAddresses = account.recoveryAddresses[assertion.recoveryAddresses[i].signer];
+      require(
+        keccak256(abi.encodePacked(recoveryAddresses)) ==
+          keccak256(abi.encodePacked(assertion.recoveryAddresses[i].recoveryAddresses)),
+        "RecoveryAddresses mismatch"
+      );
+    }
+
+    for (uint i = 0; i < assertion.onboardedWithdrawalAddresses.length; i++) {
+      require(
+        account.onboardedWithdrawalAddresses[assertion.onboardedWithdrawalAddresses[i]],
+        "OnboardedWithdrawalAddress mismatch"
+      );
+    }
+
+    for (uint i = 0; i < assertion.onboardedTransferAccounts.length; i++) {
+      require(
+        account.onboardedTransferAccounts[assertion.onboardedTransferAccounts[i]],
+        "OnboardedTransferAccount mismatch"
+      );
+    }
+
+    for (uint i = 0; i < assertion.signers.length; i++) {
+      require(account.signers[assertion.signers[i]] == assertion.signerPermissions[i], "Signer permission mismatch");
+    }
+  }
+
+  function assertSubAccount(uint64 subAccountId, SubAccountAssertion calldata assertion) public view {
+    SubAccount storage subAccount = state.subAccounts[subAccountId];
+
+    require(subAccount.id == assertion.id, "SubAccount ID mismatch");
+    require(subAccount.adminCount == assertion.adminCount, "AdminCount mismatch");
+    require(subAccount.signerCount == assertion.signerCount, "SignerCount mismatch");
+    require(subAccount.accountID == assertion.accountID, "AccountID mismatch");
+    require(subAccount.marginType == assertion.marginType, "MarginType mismatch");
+    require(subAccount.quoteCurrency == assertion.quoteCurrency, "QuoteCurrency mismatch");
+    require(
+      subAccount.lastAppliedFundingTimestamp == assertion.lastAppliedFundingTimestamp,
+      "LastAppliedFundingTimestamp mismatch"
+    );
+
+    for (uint i = 0; i < assertion.spotBalances.length; i++) {
+      require(
+        subAccount.spotBalances[assertion.spotBalances[i].currency] == assertion.spotBalances[i].balance,
+        "SpotBalance mismatch"
+      );
+    }
+
+    assertPositionsMap(subAccount.options, assertion.options, "Options");
+    assertPositionsMap(subAccount.futures, assertion.futures, "Futures");
+    assertPositionsMap(subAccount.perps, assertion.perps, "Perps");
+
+    for (uint i = 0; i < assertion.signers.length; i++) {
+      require(subAccount.signers[assertion.signers[i]] == assertion.signerPermissions[i], "Signer permission mismatch");
+    }
+  }
+
+  function assertPositionsMap(
+    PositionsMap storage posMap,
+    PositionsMapAssertion memory assertion,
+    string memory mapName
+  ) internal view {
+    require(
+      posMap.keys.length == assertion.positions.length,
+      string(abi.encodePacked(mapName, " PositionsMap length mismatch"))
+    );
+
+    for (uint i = 0; i < assertion.positions.length; i++) {
+      Position storage pos = posMap.values[assertion.positions[i].assetId];
+      require(
+        pos.balance == assertion.positions[i].balance,
+        string(abi.encodePacked(mapName, " Position balance mismatch"))
+      );
+      require(
+        pos.lastAppliedFundingIndex == assertion.positions[i].lastAppliedFundingIndex,
+        string(abi.encodePacked(mapName, " Position lastAppliedFundingIndex mismatch"))
+      );
+    }
+  }
+
+  function isAllAccountExists(address[] calldata accountIDs) public view returns (bool) {
+    for (uint256 i = 0; i < accountIDs.length; i++) {
+      if (state.accounts[accountIDs[i]].id == address(0)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function getAccountSpotBalance(address accID, Currency currency) public view returns (int64) {
+    Account storage account = state.accounts[accID];
+    return account.spotBalances[currency];
+  }
+
+  function isRecoveryAddress(address id, address signer, address recoveryAddress) public view returns (bool) {
+    Account storage account = state.accounts[id];
+    return addressExists(account.recoveryAddresses[signer], recoveryAddress);
+  }
+
+  function isOnboardedWithdrawalAddress(address id, address withdrawalAddress) public view returns (bool) {
+    Account storage account = state.accounts[id];
+    return account.onboardedWithdrawalAddresses[withdrawalAddress];
+  }
+
+  function getAccountOnboardedTransferAccount(address accID, address transferAccount) public view returns (bool) {
+    Account storage account = state.accounts[accID];
+    return account.onboardedTransferAccounts[transferAccount];
+  }
+
+  function getSignerPermission(address id, address signer) public view returns (uint64) {
+    Account storage account = state.accounts[id];
+    return account.signers[signer];
+  }
+
+  function getSessionValue(address sessionKey) public view returns (address, int64) {
+    return (state.sessions[sessionKey].subAccountSigner, state.sessions[sessionKey].expiry);
+  }
+
+  function getConfig2D(ConfigID id, bytes32 subKey) public view returns (bytes32) {
+    ConfigValue storage config = state.config2DValues[id][subKey];
+    if (config.isSet) {
+      return config.val;
+    }
+    return state.config2DValues[id][DEFAULT_CONFIG_ENTRY].val;
+  }
+
+  function config1DIsSet(ConfigID id) public view returns (bool) {
+    return state.config1DValues[id].isSet;
+  }
+
+  function config2DIsSet(ConfigID id) public view returns (bool) {
+    return state.config2DValues[id][DEFAULT_CONFIG_ENTRY].isSet;
+  }
+
+  function getConfig1D(ConfigID id) public view returns (bytes32) {
+    return state.config1DValues[id].val;
+  }
+
+  function getConfigSchedule(ConfigID id, bytes32 subKey) public view returns (int64) {
+    return state.configSettings[id].schedules[subKey].lockEndTime;
+  }
+
+  function isConfigScheduleAbsent(ConfigID id, bytes32 subKey) public view returns (bool) {
+    return state.configSettings[id].schedules[subKey].lockEndTime == 0;
+  }
+
+  function getSubAccSignerPermission(uint64 id, address signer) public view returns (uint64) {
+    SubAccount storage subAccount = state.subAccounts[id];
+    return subAccount.signers[signer];
+  }
+
+  function getFundingIndex(bytes32 assetID) public view returns (int64) {
+    return state.prices.fundingIndex[assetID];
+  }
+
+  function getFundingTime() public view returns (int64) {
+    return state.prices.fundingTime;
+  }
+
+  function getMarkPrice(bytes32 assetID) public view returns (uint64, bool) {
+    return _getMarkPrice9Decimals(assetID);
+  }
+
+  function getSettlementPrice(bytes32 assetID) public view returns (uint64, bool) {
+    SettlementPriceEntry storage entry = state.prices.settlement[assetID];
+    return (entry.value, entry.isSet);
+  }
+
+  function getInterestRate(bytes32 assetID) public view returns (int32) {
+    return state.prices.interest[assetID];
+  }
+
+  function getSubAccountValue(uint64 subAccountID) public view returns (int64) {
+    SubAccount storage sub = _requireSubAccount(subAccountID);
+    uint64 quoteDecimals = _getBalanceDecimal(sub.quoteCurrency);
+    return _getSubAccountUsdValue(sub).toInt64(quoteDecimals);
+  }
+
+  function getSubAccountPosition(
+    uint64 subAccountID,
+    bytes32 assetID
+  ) public view returns (bool found, int64 balance, int64 lastAppliedFundingIndex) {
+    SubAccount storage sub = _requireSubAccount(subAccountID);
+    PositionsMap storage posmap = _getPositionCollection(sub, assetGetKind(assetID));
+    Position storage pos = posmap.values[assetID];
+    return (pos.id != 0x0, pos.balance, pos.lastAppliedFundingIndex);
+  }
+
+  function getSubAccountSpotBalance(uint64 subAccountID, Currency currency) public view returns (int64) {
+    SubAccount storage sub = _requireSubAccount(subAccountID);
+    return sub.spotBalances[currency];
+  }
+}

--- a/contracts/exchange/api/AssertionContract.sol
+++ b/contracts/exchange/api/AssertionContract.sol
@@ -149,23 +149,22 @@ contract AssertionContract is ConfigContract, RiskCheck {
 
   function assertSubAccountValue(uint64 subAccountID, int64 expected) public view {
     int64 value = getSubAccountValue(subAccountID);
-    if (value != expected) {
-      revert(
-        string(
-          abi.encodePacked(
-            "AssertionContract: subAccountValue mismatch. ",
-            "SubAccountID: ",
-            subAccountID.toString(),
-            ", ",
-            "Expected: ",
-            _int64ToString(expected),
-            ", ",
-            "Actual: ",
-            _int64ToString(value)
-          )
+    require(
+      value == expected,
+      string(
+        abi.encodePacked(
+          "AssertionContract: subAccountValue mismatch. ",
+          "SubAccountID: ",
+          subAccountID.toString(),
+          ", ",
+          "Expected: ",
+          _int64ToString(expected),
+          ", ",
+          "Actual: ",
+          _int64ToString(value)
         )
-      );
-    }
+      )
+    );
   }
 
   function assertSubAccountPosition(
@@ -177,44 +176,62 @@ contract AssertionContract is ConfigContract, RiskCheck {
   ) public view {
     (bool found, int64 balance, int64 lastAppliedFundingIndex) = getSubAccountPosition(subAccountID, assetID);
 
-    if (found != expectedFound) {
-      revert(
-        string(
-          abi.encodePacked(
-            "AssertionContract: subAccountPosition 'found' mismatch. Expected: ",
-            expectedFound ? "true" : "false",
-            ", Actual: ",
-            found ? "true" : "false"
-          )
+    require(
+      found == expectedFound,
+      string(
+        abi.encodePacked(
+          "AssertionContract: subAccountPosition 'found' mismatch. ",
+          "SubAccountID: ",
+          subAccountID.toString(),
+          ", ",
+          "AssetID: ",
+          bytes32ToString(assetID),
+          ", ",
+          "Expected: ",
+          expectedFound ? "true" : "false",
+          ", Actual: ",
+          found ? "true" : "false"
         )
-      );
-    }
+      )
+    );
 
-    if (balance != expectedBalance) {
-      revert(
-        string(
-          abi.encodePacked(
-            "AssertionContract: subAccountPosition 'balance' mismatch. Expected: ",
-            _int64ToString(expectedBalance),
-            ", Actual: ",
-            _int64ToString(balance)
-          )
+    require(
+      balance == expectedBalance,
+      string(
+        abi.encodePacked(
+          "AssertionContract: subAccountPosition 'balance' mismatch. ",
+          "SubAccountID: ",
+          subAccountID.toString(),
+          ", ",
+          "AssetID: ",
+          bytes32ToString(assetID),
+          ", ",
+          "Expected: ",
+          _int64ToString(expectedBalance),
+          ", Actual: ",
+          _int64ToString(balance)
         )
-      );
-    }
+      )
+    );
 
-    if (lastAppliedFundingIndex != expectedLastAppliedFundingIndex) {
-      revert(
-        string(
-          abi.encodePacked(
-            "AssertionContract: subAccountPosition 'lastAppliedFundingIndex' mismatch. Expected: ",
-            _int64ToString(expectedLastAppliedFundingIndex),
-            ", Actual: ",
-            _int64ToString(lastAppliedFundingIndex)
-          )
+    require(
+      lastAppliedFundingIndex == expectedLastAppliedFundingIndex,
+      string(
+        abi.encodePacked(
+          "AssertionContract: subAccountPosition 'lastAppliedFundingIndex' mismatch. ",
+          "SubAccountID: ",
+          subAccountID.toString(),
+          ", ",
+          "AssetID: ",
+          bytes32ToString(assetID),
+          ", ",
+          "Expected: ",
+          _int64ToString(expectedLastAppliedFundingIndex),
+          ", Actual: ",
+          _int64ToString(lastAppliedFundingIndex)
         )
-      );
-    }
+      )
+    );
   }
 
   function _int64ToString(int64 value) internal pure returns (string memory) {

--- a/contracts/exchange/api/AssertionContract.sol
+++ b/contracts/exchange/api/AssertionContract.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.20;
 import "./RiskCheck.sol";
 import "../types/PositionMap.sol";
 import "./ConfigContract.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
 
 struct SpotBalanceAssertion {
   Currency currency;
@@ -50,7 +49,6 @@ struct SubAccountAssertion {
 
 contract AssertionContract is ConfigContract, RiskCheck {
   using BIMath for BI;
-  using Strings for uint64;
 
   function assertIsAllAccountExists(address[] calldata accountIDs, bool expected) public view {
     bool result = isAllAccountExists(accountIDs);
@@ -149,22 +147,7 @@ contract AssertionContract is ConfigContract, RiskCheck {
 
   function assertSubAccountValue(uint64 subAccountID, int64 expected) public view {
     int64 value = getSubAccountValue(subAccountID);
-    require(
-      value == expected,
-      string(
-        abi.encodePacked(
-          "AssertionContract: subAccountValue mismatch. ",
-          "SubAccountID: ",
-          subAccountID.toString(),
-          ", ",
-          "Expected: ",
-          _int64ToString(expected),
-          ", ",
-          "Actual: ",
-          _int64ToString(value)
-        )
-      )
-    );
+    require(value == expected, string(abi.encodePacked("AssertionContract: subAccountValue mismatch. ")));
   }
 
   function assertSubAccountPosition(
@@ -178,67 +161,18 @@ contract AssertionContract is ConfigContract, RiskCheck {
 
     require(
       found == expectedFound,
-      string(
-        abi.encodePacked(
-          "AssertionContract: subAccountPosition 'found' mismatch. ",
-          "SubAccountID: ",
-          subAccountID.toString(),
-          ", ",
-          "AssetID: ",
-          bytes32ToString(assetID),
-          ", ",
-          "Expected: ",
-          expectedFound ? "true" : "false",
-          ", Actual: ",
-          found ? "true" : "false"
-        )
-      )
+      string(abi.encodePacked("AssertionContract: subAccountPosition 'found' mismatch. "))
     );
 
     require(
       balance == expectedBalance,
-      string(
-        abi.encodePacked(
-          "AssertionContract: subAccountPosition 'balance' mismatch. ",
-          "SubAccountID: ",
-          subAccountID.toString(),
-          ", ",
-          "AssetID: ",
-          bytes32ToString(assetID),
-          ", ",
-          "Expected: ",
-          _int64ToString(expectedBalance),
-          ", Actual: ",
-          _int64ToString(balance)
-        )
-      )
+      string(abi.encodePacked("AssertionContract: subAccountPosition 'balance' mismatch. "))
     );
 
     require(
       lastAppliedFundingIndex == expectedLastAppliedFundingIndex,
-      string(
-        abi.encodePacked(
-          "AssertionContract: subAccountPosition 'lastAppliedFundingIndex' mismatch. ",
-          "SubAccountID: ",
-          subAccountID.toString(),
-          ", ",
-          "AssetID: ",
-          bytes32ToString(assetID),
-          ", ",
-          "Expected: ",
-          _int64ToString(expectedLastAppliedFundingIndex),
-          ", Actual: ",
-          _int64ToString(lastAppliedFundingIndex)
-        )
-      )
+      string(abi.encodePacked("AssertionContract: subAccountPosition 'lastAppliedFundingIndex' mismatch. "))
     );
-  }
-
-  function _int64ToString(int64 value) internal pure returns (string memory) {
-    return
-      value >= 0
-        ? string(abi.encodePacked("+", uint64(value).toString()))
-        : string(abi.encodePacked("-", uint64(-value).toString()));
   }
 
   function assertSubAccountSpotBalance(uint64 subAccountID, Currency currency, int64 expected) public view {

--- a/contracts/exchange/api/AssertionContract.sol
+++ b/contracts/exchange/api/AssertionContract.sol
@@ -147,7 +147,7 @@ contract AssertionContract is ConfigContract, RiskCheck {
 
   function assertSubAccountValue(uint64 subAccountID, int64 expected) public view {
     int64 value = getSubAccountValue(subAccountID);
-    require(value == expected, string(abi.encodePacked("AssertionContract: subAccountValue mismatch. ")));
+    require(value == expected, string(abi.encodePacked("AssertionContract: subAccountValue mismatch.")));
   }
 
   function assertSubAccountPosition(
@@ -161,17 +161,17 @@ contract AssertionContract is ConfigContract, RiskCheck {
 
     require(
       found == expectedFound,
-      string(abi.encodePacked("AssertionContract: subAccountPosition 'found' mismatch. "))
+      string(abi.encodePacked("AssertionContract: subAccountPosition 'found' mismatch."))
     );
 
     require(
       balance == expectedBalance,
-      string(abi.encodePacked("AssertionContract: subAccountPosition 'balance' mismatch. "))
+      string(abi.encodePacked("AssertionContract: subAccountPosition 'balance' mismatch."))
     );
 
     require(
       lastAppliedFundingIndex == expectedLastAppliedFundingIndex,
-      string(abi.encodePacked("AssertionContract: subAccountPosition 'lastAppliedFundingIndex' mismatch. "))
+      string(abi.encodePacked("AssertionContract: subAccountPosition 'lastAppliedFundingIndex' mismatch."))
     );
   }
 

--- a/test/foundry/api/AssertionContract.t.sol
+++ b/test/foundry/api/AssertionContract.t.sol
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../../contracts/exchange/util/Asset.sol";
+import "../../../contracts/exchange/api/AssertionContract.sol";
+import "../../../contracts/exchange/types/PositionMap.sol";
+import "../../../contracts/exchange/types/DataStructure.sol";
+
+// Mock contract to allow setting state for testing
+contract MockAssertionContract is AssertionContract {
+  function setAccount(AccountAssertion memory account) public {
+    state.accounts[account.id].id = account.id;
+    state.accounts[account.id].multiSigThreshold = account.multiSigThreshold;
+    state.accounts[account.id].adminCount = account.adminCount;
+    state.accounts[account.id].subAccounts = account.subAccounts;
+
+    for (uint i = 0; i < account.spotBalances.length; i++) {
+      state.accounts[account.id].spotBalances[account.spotBalances[i].currency] = account.spotBalances[i].balance;
+    }
+
+    for (uint i = 0; i < account.recoveryAddresses.length; i++) {
+      state.accounts[account.id].recoveryAddresses[account.recoveryAddresses[i].signer] = account
+        .recoveryAddresses[i]
+        .recoveryAddresses;
+    }
+
+    for (uint i = 0; i < account.onboardedWithdrawalAddresses.length; i++) {
+      state.accounts[account.id].onboardedWithdrawalAddresses[account.onboardedWithdrawalAddresses[i]] = true;
+    }
+
+    for (uint i = 0; i < account.onboardedTransferAccounts.length; i++) {
+      state.accounts[account.id].onboardedTransferAccounts[account.onboardedTransferAccounts[i]] = true;
+    }
+
+    for (uint i = 0; i < account.signers.length; i++) {
+      state.accounts[account.id].signers[account.signers[i].signer] = account.signers[i].permission;
+    }
+  }
+
+  function setSubAccount(SubAccountAssertion memory subAccount) public {
+    state.subAccounts[subAccount.id].id = subAccount.id;
+    state.subAccounts[subAccount.id].adminCount = subAccount.adminCount;
+    state.subAccounts[subAccount.id].signerCount = subAccount.signerCount;
+    state.subAccounts[subAccount.id].accountID = subAccount.accountID;
+    state.subAccounts[subAccount.id].marginType = subAccount.marginType;
+    state.subAccounts[subAccount.id].quoteCurrency = subAccount.quoteCurrency;
+    state.subAccounts[subAccount.id].lastAppliedFundingTimestamp = subAccount.lastAppliedFundingTimestamp;
+
+    for (uint i = 0; i < subAccount.spotBalances.length; i++) {
+      state.subAccounts[subAccount.id].spotBalances[subAccount.spotBalances[i].currency] = subAccount
+        .spotBalances[i]
+        .balance;
+    }
+
+    for (uint i = 0; i < subAccount.perps.length; i++) {
+      Position storage position = getOrNew(state.subAccounts[subAccount.id].perps, subAccount.perps[i].id);
+      position.id = subAccount.perps[i].id;
+      position.balance = subAccount.perps[i].balance;
+      position.lastAppliedFundingIndex = subAccount.perps[i].lastAppliedFundingIndex;
+    }
+
+    for (uint i = 0; i < subAccount.futures.length; i++) {
+      Position storage position = getOrNew(state.subAccounts[subAccount.id].futures, subAccount.futures[i].id);
+      position.id = subAccount.futures[i].id;
+      position.balance = subAccount.futures[i].balance;
+      position.lastAppliedFundingIndex = subAccount.futures[i].lastAppliedFundingIndex;
+    }
+
+    for (uint i = 0; i < subAccount.options.length; i++) {
+      Position storage position = getOrNew(state.subAccounts[subAccount.id].options, subAccount.options[i].id);
+      position.id = subAccount.options[i].id;
+      position.balance = subAccount.options[i].balance;
+      position.lastAppliedFundingIndex = subAccount.options[i].lastAppliedFundingIndex;
+    }
+
+    for (uint i = 0; i < subAccount.signers.length; i++) {
+      state.subAccounts[subAccount.id].signers[subAccount.signers[i].signer] = subAccount.signers[i].permission;
+    }
+  }
+
+  function setSession(address sessionKey, address signer, int64 expiry) public {
+    state.sessions[sessionKey] = Session({subAccountSigner: signer, expiry: expiry});
+  }
+
+  function setConfig2DValue(ConfigID id, bytes32 subKey, ConfigValue memory value) public {
+    state.config2DValues[id][subKey] = value;
+  }
+
+  function setConfig1DValue(ConfigID id, ConfigValue memory value) public {
+    state.config1DValues[id] = value;
+  }
+
+  // Helper function to set a specific funding index
+  function setFundingIndex(bytes32 assetID, int64 index) public {
+    state.prices.fundingIndex[assetID] = index;
+  }
+
+  // Helper function to set a specific mark price
+  function setMarkPrice(bytes32 assetID, uint64 price) public {
+    state.prices.mark[assetID] = price;
+  }
+
+  // Helper function to set a specific settlement price
+  function setSettlementPrice(bytes32 assetID, uint64 value, bool isSet) public {
+    state.prices.settlement[assetID] = SettlementPriceEntry({value: value, isSet: isSet});
+  }
+
+  // Helper function to set a specific interest rate
+  function setInterestRate(bytes32 assetID, int32 rate) public {
+    state.prices.interest[assetID] = rate;
+  }
+}
+
+contract AssertionContractTest is Test {
+  MockAssertionContract assertionContract;
+  address testAccount;
+  uint64 testSubAccount;
+
+  function setUp() public {
+    assertionContract = new MockAssertionContract();
+    testAccount = address(0x1234);
+    testSubAccount = 1;
+  }
+
+  function testAssertIsAllAccountExists() public {
+    address[] memory accounts = new address[](2);
+    accounts[0] = testAccount;
+    accounts[1] = address(0x5678);
+
+    AccountAssertion memory account1 = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+    AccountAssertion memory account2 = AccountAssertion({
+      id: address(0x5678),
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account1);
+    assertionContract.setAccount(account2);
+
+    assertionContract.assertIsAllAccountExists(accounts, true);
+  }
+
+  function testAssertAccountSpotBalance() public {
+    Currency currency = Currency.ETH;
+    int64 expectedBalance = 1000;
+
+    SpotBalanceAssertion[] memory spotBalances = new SpotBalanceAssertion[](1);
+    spotBalances[0] = SpotBalanceAssertion({currency: currency, balance: expectedBalance});
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: spotBalances,
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account);
+
+    assertionContract.assertAccountSpotBalance(testAccount, currency, expectedBalance);
+  }
+
+  function testAssertIsRecoveryAddress() public {
+    address signer = address(0x9876);
+    address recoveryAddress = address(0xABCD);
+    RecoveryAddressAssertion[] memory recoveryAddresses = new RecoveryAddressAssertion[](1);
+    recoveryAddresses[0] = RecoveryAddressAssertion({signer: signer, recoveryAddresses: new address[](1)});
+    recoveryAddresses[0].recoveryAddresses[0] = recoveryAddress;
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: recoveryAddresses,
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account);
+
+    assertionContract.assertIsRecoveryAddress(testAccount, signer, recoveryAddress, true);
+  }
+
+  function testAssertIsOnboardedWithdrawalAddress() public {
+    address withdrawalAddress = address(0xABCD);
+
+    address[] memory onboardedWithdrawalAddresses = new address[](1);
+    onboardedWithdrawalAddresses[0] = withdrawalAddress;
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: onboardedWithdrawalAddresses,
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account);
+
+    assertionContract.assertIsOnboardedWithdrawalAddress(testAccount, withdrawalAddress, true);
+  }
+
+  function testAssertAccountOnboardedTransferAccount() public {
+    address transferAccount = address(0xDEF0);
+
+    address[] memory onboardedTransferAccounts = new address[](1);
+    onboardedTransferAccounts[0] = transferAccount;
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: onboardedTransferAccounts,
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account);
+
+    assertionContract.assertAccountOnboardedTransferAccount(testAccount, transferAccount, true);
+  }
+
+  function testAssertSignerPermission() public {
+    address signer = address(0xDEF0);
+    uint64 expectedPermission = 2;
+
+    SignerAssertion[] memory signers = new SignerAssertion[](1);
+    signers[0] = SignerAssertion({signer: signer, permission: expectedPermission});
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: signers
+    });
+
+    assertionContract.setAccount(account);
+
+    assertionContract.assertSignerPermission(testAccount, signer, expectedPermission);
+  }
+
+  function testAssertSessionValue() public {
+    address sessionKey = address(0xFEDC);
+    address expectedSigner = address(0xCBA9);
+    int64 expectedExpiry = 1234567890;
+
+    assertionContract.setSession(sessionKey, expectedSigner, expectedExpiry);
+
+    assertionContract.assertSessionValue(sessionKey, expectedSigner, expectedExpiry);
+  }
+
+  function testAssertConfig2D() public {
+    ConfigID id = ConfigID.MAINTENANCE_MARGIN_TIER_01;
+    bytes32 subKey = bytes32("test_subkey");
+    bytes32 expectedValue = bytes32("test_value");
+
+    ConfigValue memory configValue = ConfigValue({isSet: true, val: expectedValue});
+
+    assertionContract.setConfig2DValue(id, subKey, configValue);
+
+    assertionContract.assertConfig2D(id, subKey, expectedValue);
+  }
+
+  function testAssertConfig1DIsSet() public {
+    ConfigID id = ConfigID.MAINTENANCE_MARGIN_TIER_01;
+
+    ConfigValue memory configValue = ConfigValue({isSet: true, val: bytes32("test_value")});
+
+    assertionContract.setConfig1DValue(id, configValue);
+
+    assertionContract.assertConfig1DIsSet(id, true);
+  }
+
+  bytes32 internal constant DEFAULT_CONFIG_ENTRY = bytes32(uint256(0));
+
+  function testAssertConfig2DIsSet() public {
+    ConfigID id = ConfigID.MAINTENANCE_MARGIN_TIER_01;
+
+    ConfigValue memory configValue = ConfigValue({isSet: true, val: bytes32("test_value")});
+
+    assertionContract.setConfig2DValue(id, DEFAULT_CONFIG_ENTRY, configValue);
+
+    assertionContract.assertConfig2DIsSet(id, true);
+  }
+
+  function testAssertConfig1D() public {
+    ConfigID id = ConfigID.MAINTENANCE_MARGIN_TIER_01;
+    bytes32 expectedValue = bytes32("test_value");
+
+    ConfigValue memory configValue = ConfigValue({isSet: true, val: expectedValue});
+
+    assertionContract.setConfig1DValue(id, configValue);
+
+    assertionContract.assertConfig1D(id, expectedValue);
+  }
+
+  function testAssertSubAccSignerPermission() public {
+    address signer = address(0xDEF0);
+    uint64 expectedPermission = 2;
+
+    SignerAssertion[] memory signers = new SignerAssertion[](1);
+    signers[0] = SignerAssertion({signer: signer, permission: expectedPermission});
+
+    SubAccountAssertion memory subAccount = SubAccountAssertion({
+      id: testSubAccount,
+      adminCount: 1,
+      signerCount: 1,
+      accountID: testAccount,
+      marginType: MarginType.SIMPLE_CROSS_MARGIN,
+      quoteCurrency: Currency.USDC,
+      lastAppliedFundingTimestamp: 0,
+      spotBalances: new SpotBalanceAssertion[](0),
+      options: new Position[](0),
+      futures: new Position[](0),
+      perps: new Position[](0),
+      signers: signers
+    });
+
+    assertionContract.setSubAccount(subAccount);
+
+    assertionContract.assertSubAccSignerPermission(testSubAccount, signer, expectedPermission);
+  }
+
+  function testAssertFundingIndex() public {
+    bytes32 assetID = bytes32("BTC-USD");
+    int64 expectedIndex = 1000000;
+
+    assertionContract.setFundingIndex(assetID, expectedIndex);
+
+    assertionContract.assertFundingIndex(assetID, expectedIndex);
+  }
+
+  function testAssertMarkPrice() public {
+    bytes32 assetID = assetToID(
+      Asset({kind: Kind.SPOT, underlying: Currency.BTC, quote: Currency.UNSPECIFIED, expiration: 0, strikePrice: 0})
+    );
+    uint64 expectedPrice = 50000 * 1e9; // 50,000 USD with 9 decimals
+    bool expectedIsSet = true;
+
+    assertionContract.setMarkPrice(assetID, expectedPrice);
+
+    assertionContract.assertMarkPrice(assetID, expectedPrice, expectedIsSet);
+  }
+
+  function testAssertSettlementPrice() public {
+    bytes32 assetID = bytes32("BTC-USD");
+    uint64 expectedValue = 49000 * 1e9; // 49,000 USD with 9 decimals
+    bool expectedIsSet = true;
+
+    assertionContract.setSettlementPrice(assetID, expectedValue, expectedIsSet);
+
+    assertionContract.assertSettlementPrice(assetID, expectedValue, expectedIsSet);
+  }
+
+  function testAssertInterestRate() public {
+    bytes32 assetID = bytes32("BTC-USD");
+    int32 expectedRate = 500; // 5% with 2 decimals
+
+    assertionContract.setInterestRate(assetID, expectedRate);
+
+    assertionContract.assertInterestRate(assetID, expectedRate);
+  }
+
+  function testAssertSubAccountPosition() public {
+    uint64 subAccountID = testSubAccount;
+    bytes32 assetID = assetToID(
+      Asset({kind: Kind.PERPS, underlying: Currency.BTC, quote: Currency.USDT, expiration: 0, strikePrice: 0})
+    );
+    bool expectedFound = true;
+    int64 expectedBalance = 100 * 1e8; // 100 contracts with 8 decimals
+    int64 expectedLastAppliedFundingIndex = 1000000;
+
+    Position[] memory positions = new Position[](1);
+    positions[0] = Position({
+      id: assetID,
+      balance: expectedBalance,
+      lastAppliedFundingIndex: expectedLastAppliedFundingIndex
+    });
+
+    SubAccountAssertion memory subAccount = SubAccountAssertion({
+      id: subAccountID,
+      adminCount: 1,
+      signerCount: 1,
+      accountID: testAccount,
+      marginType: MarginType.SIMPLE_CROSS_MARGIN,
+      quoteCurrency: Currency.USDC,
+      lastAppliedFundingTimestamp: 0,
+      spotBalances: new SpotBalanceAssertion[](0),
+      options: new Position[](0),
+      futures: new Position[](0),
+      perps: positions,
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setSubAccount(subAccount);
+
+    assertionContract.assertSubAccountPosition(
+      subAccountID,
+      assetID,
+      expectedFound,
+      expectedBalance,
+      expectedLastAppliedFundingIndex
+    );
+  }
+
+  function testAssertSubAccountSpotBalance() public {
+    Currency currency = Currency.USDT;
+    int64 expectedBalance = 2000 * 1e6; // 2,000 USDT with 6 decimals
+
+    SpotBalanceAssertion[] memory spotBalances = new SpotBalanceAssertion[](1);
+    spotBalances[0] = SpotBalanceAssertion({currency: currency, balance: expectedBalance});
+
+    bytes32 assetID = assetToID(
+      Asset({kind: Kind.SPOT, underlying: Currency.USDT, quote: Currency.UNSPECIFIED, expiration: 0, strikePrice: 0})
+    );
+    uint64 expectedPrice = 2000000000; // 2 USD/USDT with 9 decimals
+
+    assertionContract.setMarkPrice(assetID, expectedPrice);
+
+    SubAccountAssertion memory subAccount = SubAccountAssertion({
+      id: testSubAccount,
+      adminCount: 1,
+      signerCount: 1,
+      accountID: testAccount,
+      marginType: MarginType.SIMPLE_CROSS_MARGIN,
+      quoteCurrency: Currency.USDT,
+      lastAppliedFundingTimestamp: 0,
+      spotBalances: spotBalances,
+      options: new Position[](0),
+      futures: new Position[](0),
+      perps: new Position[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setSubAccount(subAccount);
+
+    assertionContract.assertSubAccountSpotBalance(testSubAccount, currency, expectedBalance);
+
+    assertionContract.assertSubAccountValue(testSubAccount, expectedBalance * 2);
+  }
+}

--- a/test/foundry/api/AssertionContract.t.sol
+++ b/test/foundry/api/AssertionContract.t.sol
@@ -474,4 +474,404 @@ contract AssertionContractTest is Test {
 
     assertionContract.assertSubAccountValue(testSubAccount, expectedBalance * 2);
   }
+
+  function testAssertIsAllAccountExistsFail() public {
+    address[] memory accounts = new address[](2);
+    accounts[0] = testAccount;
+    accounts[1] = address(0x5678);
+
+    AccountAssertion memory account1 = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account1);
+
+    vm.expectRevert("AssertionContract: isAllAccountExists assertion failed");
+    assertionContract.assertIsAllAccountExists(accounts, true);
+  }
+
+  function testAssertAccountSpotBalanceFail() public {
+    Currency currency = Currency.ETH;
+    int64 expectedBalance = 1000;
+    int64 actualBalance = 500;
+
+    SpotBalanceAssertion[] memory spotBalances = new SpotBalanceAssertion[](1);
+    spotBalances[0] = SpotBalanceAssertion({currency: currency, balance: actualBalance});
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: spotBalances,
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account);
+
+    vm.expectRevert("AssertionContract: accountSpotBalance assertion failed");
+    assertionContract.assertAccountSpotBalance(testAccount, currency, expectedBalance);
+  }
+
+  function testAssertIsRecoveryAddressFail() public {
+    address signer = address(0x9876);
+    address recoveryAddress = address(0xABCD);
+    address wrongRecoveryAddress = address(0xABCC);
+
+    RecoveryAddressAssertion[] memory recoveryAddresses = new RecoveryAddressAssertion[](1);
+    recoveryAddresses[0] = RecoveryAddressAssertion({signer: signer, recoveryAddresses: new address[](1)});
+    recoveryAddresses[0].recoveryAddresses[0] = recoveryAddress;
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: recoveryAddresses,
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account);
+
+    vm.expectRevert("AssertionContract: isRecoveryAddress assertion failed");
+    assertionContract.assertIsRecoveryAddress(testAccount, signer, wrongRecoveryAddress, true);
+  }
+
+  function testAssertIsOnboardedWithdrawalAddressFail() public {
+    address withdrawalAddress = address(0xABCD);
+    address wrongWithdrawalAddress = address(0xABCC);
+
+    address[] memory onboardedWithdrawalAddresses = new address[](1);
+    onboardedWithdrawalAddresses[0] = withdrawalAddress;
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: onboardedWithdrawalAddresses,
+      onboardedTransferAccounts: new address[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account);
+
+    vm.expectRevert("AssertionContract: isOnboardedWithdrawalAddress assertion failed");
+    assertionContract.assertIsOnboardedWithdrawalAddress(testAccount, wrongWithdrawalAddress, true);
+  }
+
+  function testAssertAccountOnboardedTransferAccountFail() public {
+    address transferAccount = address(0xDEF0);
+    address wrongTransferAccount = address(0xABCD);
+
+    address[] memory onboardedTransferAccounts = new address[](1);
+    onboardedTransferAccounts[0] = transferAccount;
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: onboardedTransferAccounts,
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setAccount(account);
+
+    vm.expectRevert("AssertionContract: accountOnboardedTransferAccount assertion failed");
+    assertionContract.assertAccountOnboardedTransferAccount(testAccount, wrongTransferAccount, true);
+  }
+
+  function testAssertSignerPermissionFail() public {
+    address signer = address(0xDEF0);
+    uint64 expectedPermission = 2;
+    uint64 actualPermission = 1;
+
+    SignerAssertion[] memory signers = new SignerAssertion[](1);
+    signers[0] = SignerAssertion({signer: signer, permission: actualPermission});
+
+    AccountAssertion memory account = AccountAssertion({
+      id: testAccount,
+      multiSigThreshold: 1,
+      adminCount: 1,
+      subAccounts: new uint64[](0),
+      spotBalances: new SpotBalanceAssertion[](0),
+      recoveryAddresses: new RecoveryAddressAssertion[](0),
+      onboardedWithdrawalAddresses: new address[](0),
+      onboardedTransferAccounts: new address[](0),
+      signers: signers
+    });
+
+    assertionContract.setAccount(account);
+
+    vm.expectRevert("AssertionContract: signerPermission assertion failed");
+    assertionContract.assertSignerPermission(testAccount, signer, expectedPermission);
+  }
+
+  function testAssertSessionValueFail() public {
+    address sessionKey = address(0xFEDC);
+    address expectedSigner = address(0xCBA9);
+    address actualSigner = address(0xABCD);
+    int64 expectedExpiry = 1234567890;
+
+    assertionContract.setSession(sessionKey, actualSigner, expectedExpiry);
+
+    vm.expectRevert("AssertionContract: sessionValue assertion failed");
+    assertionContract.assertSessionValue(sessionKey, expectedSigner, expectedExpiry);
+  }
+
+  function testAssertConfig2DFail() public {
+    ConfigID id = ConfigID.MAINTENANCE_MARGIN_TIER_01;
+    bytes32 subKey = bytes32("test_subkey");
+    bytes32 expectedValue = bytes32("expected_value");
+    bytes32 actualValue = bytes32("actual_value");
+
+    ConfigValue memory configValue = ConfigValue({isSet: true, val: actualValue});
+
+    assertionContract.setConfig2DValue(id, subKey, configValue);
+
+    vm.expectRevert("AssertionContract: config2D assertion failed");
+    assertionContract.assertConfig2D(id, subKey, expectedValue);
+  }
+
+  function testAssertConfig1DIsSetFail() public {
+    ConfigID id = ConfigID.MAINTENANCE_MARGIN_TIER_01;
+
+    ConfigValue memory configValue = ConfigValue({isSet: false, val: bytes32(0)});
+
+    assertionContract.setConfig1DValue(id, configValue);
+
+    vm.expectRevert("AssertionContract: config1DIsSet assertion failed");
+    assertionContract.assertConfig1DIsSet(id, true);
+  }
+
+  function testAssertConfig2DIsSetFail() public {
+    ConfigID id = ConfigID.MAINTENANCE_MARGIN_TIER_01;
+
+    ConfigValue memory configValue = ConfigValue({isSet: false, val: bytes32(0)});
+
+    assertionContract.setConfig2DValue(id, DEFAULT_CONFIG_ENTRY, configValue);
+
+    vm.expectRevert("AssertionContract: config2DIsSet assertion failed");
+    assertionContract.assertConfig2DIsSet(id, true);
+  }
+
+  function testAssertConfig1DFail() public {
+    ConfigID id = ConfigID.MAINTENANCE_MARGIN_TIER_01;
+    bytes32 expectedValue = bytes32("expected_value");
+    bytes32 actualValue = bytes32("actual_value");
+
+    ConfigValue memory configValue = ConfigValue({isSet: true, val: actualValue});
+
+    assertionContract.setConfig1DValue(id, configValue);
+
+    vm.expectRevert("AssertionContract: config1D assertion failed");
+    assertionContract.assertConfig1D(id, expectedValue);
+  }
+
+  function testAssertSubAccSignerPermissionFail() public {
+    address signer = address(0xDEF0);
+    uint64 expectedPermission = 2;
+    uint64 actualPermission = 1;
+
+    SignerAssertion[] memory signers = new SignerAssertion[](1);
+    signers[0] = SignerAssertion({signer: signer, permission: actualPermission});
+
+    SubAccountAssertion memory subAccount = SubAccountAssertion({
+      id: testSubAccount,
+      adminCount: 1,
+      signerCount: 1,
+      accountID: testAccount,
+      marginType: MarginType.SIMPLE_CROSS_MARGIN,
+      quoteCurrency: Currency.USDC,
+      lastAppliedFundingTimestamp: 0,
+      spotBalances: new SpotBalanceAssertion[](0),
+      options: new Position[](0),
+      futures: new Position[](0),
+      perps: new Position[](0),
+      signers: signers
+    });
+
+    assertionContract.setSubAccount(subAccount);
+
+    vm.expectRevert("AssertionContract: subAccSignerPermission assertion failed");
+    assertionContract.assertSubAccSignerPermission(testSubAccount, signer, expectedPermission);
+  }
+
+  function testAssertFundingIndexFail() public {
+    bytes32 assetID = bytes32("BTC-USD");
+    int64 expectedIndex = 1000000;
+    int64 actualIndex = 500000;
+
+    assertionContract.setFundingIndex(assetID, actualIndex);
+
+    vm.expectRevert("AssertionContract: fundingIndex assertion failed");
+    assertionContract.assertFundingIndex(assetID, expectedIndex);
+  }
+
+  function testAssertMarkPriceFail() public {
+    bytes32 assetID = assetToID(
+      Asset({kind: Kind.SPOT, underlying: Currency.BTC, quote: Currency.UNSPECIFIED, expiration: 0, strikePrice: 0})
+    );
+    uint64 expectedPrice = 50000 * 1e9; // 50,000 USD with 9 decimals
+    uint64 actualPrice = 49000 * 1e9; // 49,000 USD with 9 decimals
+
+    assertionContract.setMarkPrice(assetID, actualPrice);
+
+    vm.expectRevert("AssertionContract: markPrice assertion failed");
+    assertionContract.assertMarkPrice(assetID, expectedPrice, true);
+  }
+
+  function testAssertSettlementPriceFail() public {
+    bytes32 assetID = bytes32("BTC-USD");
+    uint64 expectedValue = 49000 * 1e9; // 49,000 USD with 9 decimals
+    uint64 actualValue = 48000 * 1e9; // 48,000 USD with 9 decimals
+    bool expectedIsSet = true;
+
+    assertionContract.setSettlementPrice(assetID, actualValue, expectedIsSet);
+
+    vm.expectRevert("AssertionContract: settlementPrice assertion failed");
+    assertionContract.assertSettlementPrice(assetID, expectedValue, expectedIsSet);
+  }
+
+  function testAssertInterestRateFail() public {
+    bytes32 assetID = bytes32("BTC-USD");
+    int32 expectedRate = 500; // 5% with 2 decimals
+    int32 actualRate = 400; // 4% with 2 decimals
+
+    assertionContract.setInterestRate(assetID, actualRate);
+
+    vm.expectRevert("AssertionContract: interestRate assertion failed");
+    assertionContract.assertInterestRate(assetID, expectedRate);
+  }
+
+  function testAssertSubAccountPositionFail() public {
+    uint64 subAccountID = testSubAccount;
+    bytes32 assetID = assetToID(
+      Asset({kind: Kind.PERPS, underlying: Currency.BTC, quote: Currency.USDT, expiration: 0, strikePrice: 0})
+    );
+    bool expectedFound = true;
+    int64 expectedBalance = 100 * 1e8; // 100 contracts with 8 decimals
+    int64 actualBalance = 50 * 1e8; // 50 contracts with 8 decimals
+    int64 expectedLastAppliedFundingIndex = 1000000;
+    int64 actualLastAppliedFundingIndex = 500000;
+
+    Position[] memory positions = new Position[](1);
+    positions[0] = Position({
+      id: assetID,
+      balance: actualBalance,
+      lastAppliedFundingIndex: actualLastAppliedFundingIndex
+    });
+
+    SubAccountAssertion memory subAccount = SubAccountAssertion({
+      id: subAccountID,
+      adminCount: 1,
+      signerCount: 1,
+      accountID: testAccount,
+      marginType: MarginType.SIMPLE_CROSS_MARGIN,
+      quoteCurrency: Currency.USDC,
+      lastAppliedFundingTimestamp: 0,
+      spotBalances: new SpotBalanceAssertion[](0),
+      options: new Position[](0),
+      futures: new Position[](0),
+      perps: positions,
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setSubAccount(subAccount);
+
+    vm.expectRevert("AssertionContract: subAccountPosition 'balance' mismatch.");
+    assertionContract.assertSubAccountPosition(
+      subAccountID,
+      assetID,
+      expectedFound,
+      expectedBalance,
+      expectedLastAppliedFundingIndex
+    );
+  }
+
+  function testAssertSubAccountSpotBalanceFail() public {
+    Currency currency = Currency.USDT;
+    int64 expectedBalance = 2000 * 1e6; // 2,000 USDT with 6 decimals
+    int64 actualBalance = 1000 * 1e6; // 1,000 USDT with 6 decimals
+
+    SpotBalanceAssertion[] memory spotBalances = new SpotBalanceAssertion[](1);
+    spotBalances[0] = SpotBalanceAssertion({currency: currency, balance: actualBalance});
+
+    SubAccountAssertion memory subAccount = SubAccountAssertion({
+      id: testSubAccount,
+      adminCount: 1,
+      signerCount: 1,
+      accountID: testAccount,
+      marginType: MarginType.SIMPLE_CROSS_MARGIN,
+      quoteCurrency: Currency.USDT,
+      lastAppliedFundingTimestamp: 0,
+      spotBalances: spotBalances,
+      options: new Position[](0),
+      futures: new Position[](0),
+      perps: new Position[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setSubAccount(subAccount);
+
+    vm.expectRevert("AssertionContract: subAccountSpotBalance assertion failed");
+    assertionContract.assertSubAccountSpotBalance(testSubAccount, currency, expectedBalance);
+  }
+
+  function testAssertSubAccountValueFail() public {
+    Currency currency = Currency.USDT;
+    int64 balance = 2000 * 1e6; // 2,000 USDT with 6 decimals
+    int64 expectedValue = 4000 * 1e6; // 4,000 USD with 6 decimals
+    int64 actualValue = 3000 * 1e6; // 3,000 USD with 6 decimals
+
+    SpotBalanceAssertion[] memory spotBalances = new SpotBalanceAssertion[](1);
+    spotBalances[0] = SpotBalanceAssertion({currency: currency, balance: balance});
+
+    bytes32 assetID = assetToID(
+      Asset({kind: Kind.SPOT, underlying: Currency.USDT, quote: Currency.UNSPECIFIED, expiration: 0, strikePrice: 0})
+    );
+    uint64 price = 1500000000; // 1.5 USD/USDT with 9 decimals
+
+    assertionContract.setMarkPrice(assetID, price);
+
+    SubAccountAssertion memory subAccount = SubAccountAssertion({
+      id: testSubAccount,
+      adminCount: 1,
+      signerCount: 1,
+      accountID: testAccount,
+      marginType: MarginType.SIMPLE_CROSS_MARGIN,
+      quoteCurrency: Currency.USDT,
+      lastAppliedFundingTimestamp: 0,
+      spotBalances: spotBalances,
+      options: new Position[](0),
+      futures: new Position[](0),
+      perps: new Position[](0),
+      signers: new SignerAssertion[](0)
+    });
+
+    assertionContract.setSubAccount(subAccount);
+
+    vm.expectRevert("AssertionContract: subAccountValue mismatch.");
+    assertionContract.assertSubAccountValue(testSubAccount, expectedValue);
+  }
 }


### PR DESCRIPTION
- Add `AssertionContract` for risk-chain divergence prevention
- All methods in `GRVTExchangeTest` are preserved => RTF continues to work