### PR TITLE
spearbit-27: only support BTC/ETH underlying on day 1

### DIFF
--- a/contracts/exchange/api/TradeContract.sol
+++ b/contracts/exchange/api/TradeContract.sol
@@ -228,9 +228,11 @@ abstract contract TradeContract is ConfigContract, FundingAndSettlement, RiskChe
     for (uint i; i < legsLen; ++i) {
       OrderLeg calldata leg = legs[i];
       Currency assetQuote = assetGetQuote(leg.assetID);
+      Currency underlying = assetGetUnderlying(leg.assetID);
       require(assetQuote == subQuote, ERR_MISMATCH_QUOTE_CURRENCY);
       require(assetGetKind(leg.assetID) == Kind.PERPS, ERR_NOT_SUPPORTED);
       require(assetQuote == Currency.USDT, ERR_NOT_SUPPORTED);
+      require(underlying == Currency.ETH || underlying == Currency.BTC, ERR_NOT_SUPPORTED);
     }
 
     // Check the order signature


### PR DESCRIPTION
Resolution:
- We only support BTC/ETH underlying on day 1
- Support for non BTC/ETH will require contract upgrades

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/ea0a9721-7021-49da-98b0-b2adeeca45ba">
