### PR TITLE
Config verification

### DIFF
--- a/contracts/exchange/api/MarginConfigContract.sol
+++ b/contracts/exchange/api/MarginConfigContract.sol
@@ -29,6 +29,9 @@ contract MarginConfigContract is ConfigContract {
     state.simpleCrossMaintenanceMarginTimelockEndTime[kud] =
       timestamp +
       _getSimpleCrossMaintenanceMarginTiersLockDuration(kud, tiersBI);
+
+    state.configVersion++;
+    _sendConfigProofMessageToL1(abi.encode(timestamp, kud, tiers));
   }
 
   function setSimpleCrossMaintenanceMarginTiers(
@@ -62,6 +65,9 @@ contract MarginConfigContract is ConfigContract {
 
     state.simpleCrossMaintenanceMarginTiers[kud] = tiersBI;
     delete state.simpleCrossMaintenanceMarginTimelockEndTime[kud];
+
+    state.configVersion++;
+    _sendConfigProofMessageToL1(abi.encode(timestamp, kud, tiers));
   }
 
   function _requireValidMarginTiers(MarginTier[] calldata marginTiers) private pure {

--- a/contracts/exchange/types/DataStructure.sol
+++ b/contracts/exchange/types/DataStructure.sol
@@ -122,6 +122,8 @@ struct State {
   mapping(bytes32 => TmpLegData) _tmpTakerLegs;
   // This is the address that is used to initialize the config. Provided in initialize()
   address initializeConfigSigner;
+  // uint configVersion
+  uint configVersion;
   // This empty reserved space is put in place to allow future versions to add new
   // variables without shifting down storage in the inheritance chain.
   // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps


### PR DESCRIPTION
- Add and maintain `configVersion` in state
- Send message to L1 on config change
- Add `proveConfig` function to send `configVersion` to L1(to prove absence of config change)