### PR TITLE
fix: incorrect reduce only check

### DIFF
--- a/contracts/exchange/api/TradeContract.sol
+++ b/contracts/exchange/api/TradeContract.sol
@@ -172,7 +172,7 @@ abstract contract TradeContract is ConfigContract, FundingAndSettlement, RiskChe
 
     // Always allow non-liquidation orders that reduce position size
     // Liquidation orders must maintain subaccount above maintenance margin
-    bool isReducingOrder = _isReducingOrder(sub, order);
+    bool isReducingOrder = _isReducingOrder(sub, order, calcResult.matchedSizes);
     if (!order.isLiquidation && isReducingOrder) {
       _executeOrder(sub, order, calcResult, totalFee);
       return;

--- a/test/foundry/RiskCheck.t.sol
+++ b/test/foundry/RiskCheck.t.sol
@@ -264,7 +264,11 @@ contract RiskCheckTest is Test, RiskCheck {
 
   // External helper to expose _isReducingSize for testing
   function orderReducesPosition(Order calldata order) external view returns (bool) {
-    return _isReducingOrder(subAccount, order);
+    uint64[] memory matchedSizes = new uint64[](order.legs.length);
+    for (uint256 i = 0; i < order.legs.length; i++) {
+      matchedSizes[i] = order.legs[i].size;
+    }
+    return _isReducingOrder(subAccount, order, matchedSizes);
   }
 
   function _getPerp(Currency underlying) private returns (bytes32) {


### PR DESCRIPTION
The existing implementation was incorrectly using `leg.size` instead of the traded size for the reduce position check.
I also upgrade anvil-zksync since the latest version support protocol v26

```
Ran 1 test for test/foundry/util/Asset.t.sol:AssetHelperTest
[PASS] testParseAssetID() (gas: 39499)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 5.75ms (978.42µs CPU time)

Ran 7 tests for test/foundry/RiskCheck.t.sol:RiskCheckTest
[PASS] test_IsReducingSize_FullClose() (gas: 98874)
[PASS] test_IsReducingSize_MultipleLegs_AllReducing() (gas: 282918)
[PASS] test_IsReducingSize_MultipleLegs_MixedPositions() (gas: 353893)
[PASS] test_IsReducingSize_MultipleLegs_OneNotReducing() (gas: 282933)
[PASS] test_IsReducingSize_NegativePosition() (gas: 98484)
[PASS] test_IsReducingSize_NotReducing() (gas: 98090)
[PASS] test_IsReducingSize_PositivePosition() (gas: 98251)
Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 6.31ms (1.08ms CPU time)

Ran 6 tests for test/foundry/util/Address.t.sol:AddressTest
[PASS] testAddAddress() (gas: 116878)
[PASS] testAddressExists() (gas: 1744)
[PASS] testRemoveAddress() (gas: 133072)
[PASS] testSignerHasPermAccount() (gas: 23491)
[PASS] testSignerHasPermMock() (gas: 22318)
[PASS] testSignerHasPermSubAccount() (gas: 22538)
Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 6.68ms (1.95ms CPU time)

Ran 9 tests for test/foundry/util/BIMath.t.sol:BIMathTest
[PASS] testAdd() (gas: 3129)
[PASS] testDiv() (gas: 37472)
[PASS] testMul() (gas: 8007)
[PASS] testNegSub() (gas: 1564)
[PASS] testRound() (gas: 55992)
[PASS] testRoundDown() (gas: 47844)
[PASS] testRoundUp() (gas: 64385)
[PASS] testScale() (gas: 9720)
[PASS] testSub() (gas: 3796)
Suite result: ok. 9 passed; 0 failed; 0 skipped; finished in 6.68ms (6.66ms CPU time)

Ran 4 test suites in 161.45ms (25.43ms CPU time): 23 tests passed, 0 failed, 0 skipped (23 total tests)
✨  Done in 229.58s.
```